### PR TITLE
[FEAT] 공통 컴포넌트 (Button, Input)

### DIFF
--- a/src/components/common/Input/Input.styles.ts
+++ b/src/components/common/Input/Input.styles.ts
@@ -1,0 +1,123 @@
+import { StyleSheet, ViewStyle, TextStyle, Platform } from "react-native";
+
+import { theme, textFieldErrorFocusShadow } from "@/src/constants";
+
+// 타입을 먼저 정의하여 분기 스타일의 기준 설정
+export type SizeType = "sm" | "md" | "lg";
+export type VariantType = "primary" | "neutral" | "underline";
+
+// View(박스)에 줄 스타일
+export const wrapperVariants: Record<VariantType, ViewStyle> =
+  StyleSheet.create({
+    primary: {
+      backgroundColor: theme.colors.bg,
+      borderColor: theme.colors.border,
+      borderWidth: 1,
+    },
+    neutral: {
+      backgroundColor: theme.colors.gray100,
+      borderColor: theme.colors.gray200,
+      borderWidth: 1,
+    },
+    underline: {
+      backgroundColor: "transparent",
+      borderBottomColor: theme.colors.border, // 아래쪽 테두리 색상
+      borderBottomWidth: 1, // 아래쪽 테두리 두께만 1로
+      borderRadius: 0, // 기본 컨테이너의 둥근 모서리 제거
+      paddingHorizontal: 0,
+    },
+  });
+
+// 네이티브는 View에 text와 관련된 스타일 사용 불가 따로 만들어서 적용해야 함
+export const wrapperSizes: Record<SizeType, ViewStyle> = StyleSheet.create({
+  sm: { height: 40, paddingHorizontal: theme.spacing.md },
+  md: { height: 44, paddingHorizontal: 14 },
+  lg: { height: 52, paddingHorizontal: theme.spacing.base },
+});
+
+export const inputSizes: Record<SizeType, TextStyle> = StyleSheet.create({
+  sm: { fontSize: theme.fontSizes.xs },
+  md: { fontSize: theme.fontSizes.sm },
+  lg: { fontSize: theme.fontSizes.base },
+});
+
+export const focusedVariants: Record<VariantType, ViewStyle> =
+  StyleSheet.create({
+    primary: {
+      borderColor: theme.colors.main,
+      borderWidth: 2,
+    },
+    neutral: {
+      borderColor: theme.colors.main,
+      borderWidth: 2,
+    },
+    underline: {
+      borderBottomColor: theme.colors.main,
+      borderBottomWidth: 2,
+    },
+  });
+
+export const errorVariants: Record<VariantType, ViewStyle> = StyleSheet.create({
+  primary: {
+    borderColor: theme.colors.error,
+    borderWidth: 1,
+    ...textFieldErrorFocusShadow(),
+  },
+  neutral: {
+    borderColor: theme.colors.error,
+    borderWidth: 1,
+    ...textFieldErrorFocusShadow(),
+  },
+  underline: {
+    borderBottomColor: theme.colors.error, // 아래쪽만 에러 색상
+    borderBottomWidth: 1,
+  },
+});
+
+export const inputStyles = StyleSheet.create({
+  wrapper: {
+    flexDirection: "column",
+    gap: 6,
+  },
+
+  label: {
+    fontSize: theme.fontSizes.sm,
+    fontWeight: theme.fontWeights.semibold,
+    width: "100%",
+    color: theme.colors.text,
+  },
+
+  inputContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: theme.spacing.sm,
+    borderRadius: theme.borderRadius.base,
+  },
+
+  input: {
+    flex: 1,
+    backgroundColor: "transparent",
+    color: theme.colors.text,
+    ...Platform.select({
+      android: {
+        paddingVertical: 0,
+      },
+    }),
+  },
+
+  iconWrapper: {
+    justifyContent: "center",
+    alignItems: "center",
+  },
+
+  errorMessage: {
+    fontSize: theme.fontSizes.xs,
+    color: theme.colors.error,
+    marginTop: theme.spacing.xs,
+    marginLeft: theme.spacing.xs,
+  },
+
+  disabledContainer: {
+    backgroundColor: theme.colors.gray100,
+  },
+});

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -1,0 +1,135 @@
+import React, {
+  forwardRef,
+  useRef,
+  useImperativeHandle,
+  useState,
+} from "react";
+import {
+  TextInput,
+  TextInputProps,
+  View,
+  Text,
+  Pressable,
+  StyleProp,
+  ViewStyle,
+  TextStyle,
+} from "react-native";
+
+import {
+  VariantType,
+  SizeType,
+  inputStyles,
+  wrapperVariants,
+  inputSizes,
+  wrapperSizes,
+  focusedVariants,
+  errorVariants,
+} from "./Input.styles";
+
+import { theme } from "@/src/constants";
+
+interface InputProps extends TextInputProps {
+  variant?: VariantType;
+  size?: SizeType;
+  fullWidth?: boolean;
+  errorMessage?: string;
+  label?: string;
+  startIcon?: React.ReactNode;
+  endIcon?: React.ReactNode;
+
+  //className 역할 - 부모에서 내려주는 스타일 속성 전달
+  wrapperStyle?: StyleProp<ViewStyle>; // 1. 최상위 레이아웃용
+  containerStyle?: StyleProp<ViewStyle>; // 2. 중간 박스 디자인 덮어쓰기용
+  textStyle?: StyleProp<TextStyle>; // 3. 내부 텍스트 디자인 덮어쓰기용
+}
+
+export const Input = forwardRef<TextInput, InputProps>(
+  (
+    {
+      label,
+      errorMessage,
+      editable = true, // true일 때 편집 가능, false일 때 편집 불가능(disabled)
+      variant = "primary",
+      size = "md",
+      fullWidth = true,
+      startIcon,
+      endIcon,
+      wrapperStyle,
+      containerStyle,
+      textStyle,
+      onFocus,
+      onBlur,
+      ...props
+    },
+    ref,
+  ) => {
+    const innerRef = useRef<TextInput>(null);
+
+    const [isFocused, setIsFocused] = useState(false);
+
+    useImperativeHandle(ref, () => innerRef.current as TextInput);
+
+    const handleContainerClick = () => {
+      // 외부에서 ref를 안 줘도, 내부 innerRef로 포커스 가능
+      innerRef.current?.focus();
+    };
+
+    const handleFocus: TextInputProps["onFocus"] = (e) => {
+      setIsFocused(true);
+      onFocus?.(e);
+    };
+
+    const handleBlur: TextInputProps["onBlur"] = (e) => {
+      setIsFocused(false);
+      onBlur?.(e);
+    };
+
+    return (
+      <View
+        style={[
+          inputStyles.wrapper,
+          fullWidth ? { width: "100%" } : { width: "auto" },
+          wrapperStyle,
+        ]}
+      >
+        {label && <Text style={inputStyles.label}>{label}</Text>}
+
+        <Pressable
+          onPress={handleContainerClick}
+          disabled={!editable}
+          style={[
+            inputStyles.inputContainer,
+            wrapperSizes[size], // 박스 사이즈
+            wrapperVariants[variant], // 박스 배경, 테두리색
+            isFocused && !errorMessage ? focusedVariants[variant] : null,
+            errorMessage ? errorVariants[variant] : null, // 에러 시 빨간 테두리
+            !editable ? inputStyles.disabledContainer : null, // 비활성화 시 배경색
+            containerStyle,
+          ]}
+        >
+          {startIcon && (
+            <View style={inputStyles.iconWrapper}>{startIcon}</View>
+          )}
+
+          <TextInput
+            ref={innerRef}
+            style={[inputStyles.input, inputSizes[size], textStyle]}
+            editable={editable}
+            placeholderTextColor={theme.colors.gray400}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            {...props}
+          />
+
+          {endIcon && <View style={inputStyles.iconWrapper}>{endIcon}</View>}
+        </Pressable>
+
+        {errorMessage && (
+          <Text style={inputStyles.errorMessage}>{errorMessage}</Text>
+        )}
+      </View>
+    );
+  },
+);
+
+Input.displayName = "Input";

--- a/src/components/common/Input/README.md
+++ b/src/components/common/Input/README.md
@@ -1,0 +1,96 @@
+# Input
+
+단일 줄 입력용 공통 컴포넌트입니다. `TextInput` 기반이며 라벨, 에러 메시지, 좌우 아이콘 배치 및 3가지 디자인 타입(Variant)을 지원합니다. 스타일은 `@/src/constants`의 `theme` 토큰을 기반으로 합니다.
+
+> 💡 **다중 줄(Multi-line) 입력**이 필요한 경우, 이 컴포넌트 대신 `TextField` 컴포넌트를 사용
+
+## Import
+
+```tsx
+import { Input } from "@/src/components/common/Input";
+import type {
+  VariantType,
+  SizeType,
+} from "@/src/components/common/Input/Input.styles";
+```
+
+## Props
+
+| Prop               | 타입                                        | 기본값      | 설명                                                                               |
+| ------------------ | ------------------------------------------- | ----------- | ---------------------------------------------------------------------------------- |
+| **label**          | `string`                                    | -           | 입력창 상단에 표시될 라벨 텍스트                                                   |
+| **errorMessage**   | `string`                                    | -           | 에러 메시지 (값 존재 시 테두리가 빨간색으로 변경됨)                                |
+| **variant**        | `"primary"` \| `"neutral"` \| `"underline"` | `"primary"` | primary: 흰 배경 박스<br>neutral: 회색 배경 박스<br>underline: 배경 없는 밑줄 형태 |
+| **size**           | `"sm"` \| `"md"` \| `"lg"`                  | `"md"`      | 입력 박스의 높이, 좌우 패딩 및 폰트 크기                                           |
+| **fullWidth**      | `boolean`                                   | `true`      | `true` 시 너비 100%, `false` 시 컨텐츠 크기(auto)                                  |
+| **startIcon**      | `React.ReactNode`                           | -           | 입력창 내부 좌측에 배치할 아이콘 (SVG 컴포넌트 등)                                 |
+| **endIcon**        | `React.ReactNode`                           | -           | 입력창 내부 우측에 배치할 아이콘                                                   |
+| **editable**       | `boolean`                                   | `true`      | `false` 시 비활성화(Disabled) 상태 스타일 적용 및 터치 차단                        |
+| **wrapperStyle**   | `StyleProp<ViewStyle>`                      | -           | **최상위 래퍼 스타일** (주로 외부 여백 margin, 전체 width 조절 시 사용)            |
+| **containerStyle** | `StyleProp<ViewStyle>`                      | -           | **중간 박스 스타일** (테두리, 배경색 등 예외적 덮어쓰기 용도)                      |
+| **textStyle**      | `StyleProp<TextStyle>`                      | -           | **내부 텍스트 스타일** (글자색, 폰트 등 예외적 덮어쓰기 용도)                      |
+
+> **💡 기본 TextInput 속성 지원**
+> 이 컴포넌트는 React Native의 기본 `TextInput`을 확장하므로, `onChangeText`, `value`, `secureTextEntry`, `keyboardType`, `maxLength` 등 기존 `TextInput`의 모든 속성을 그대로 사용할 수 있습니다.
+
+## 사용 예시
+
+```tsx
+import { Input } from "@/src/components/common/Input";
+import LocationIcon from "@/assets/icons/location.svg"; // 예시 아이콘
+
+// 1) 기본 사용 (primary)
+<Input label="아이디" placeholder="아이디를 입력해주세요." />
+
+// 2) 회색 배경 (neutral)
+<Input label="모임 장소" placeholder="장소를 검색하세요" variant="neutral" />
+
+// 3) 밑줄 형태 (underline)
+<Input label="제목" placeholder="코스 게시글 제목을 입력하세요" variant="underline" />
+
+// 4) 에러 상태 표시
+<Input
+  label="비밀번호"
+  errorMessage="비밀번호가 일치하지 않습니다."
+/>
+
+// 5) 아이콘 포함 (startIcon / endIcon)
+<Input
+  startIcon={<LocationIcon width={20} height={20} />}
+  placeholder="여의도 한강공원 멀티플라자"
+/>
+```
+
+## 커스텀 스타일 및 확장성
+
+기본적으로는 `variant`와 `size`를 사용하여 디자인 일관성을 유지합니다. 하지만 특정 화면에서만 **예외적으로 완전히 다른 색상이나 폰트 스타일, 여백이 필요한 경우**, 아래의 3가지 프롭을 통해 기본 스타일을 덮어쓸 수 있습니다.
+
+- `wrapperStyle`: 최상위 레이아웃 제어 (외부 여백 `margin`, 위치 등)
+- `containerStyle`: 입력 박스 디자인 제어 (`backgroundColor`, `borderColor`, `borderRadius` 등)
+- `textStyle`: 내부 텍스트 디자인 제어 (`fontSize`, `color`, `fontWeight` 등)
+
+```tsx
+// ❌ 잘못된 사용: 컴포넌트에 기본 style 주입 불가
+<Input style={{ marginBottom: 20 }} />
+
+// ✅ 올바른 사용 1: wrapperStyle을 통한 외부 레이아웃 제어
+<Input
+  label="나이"
+  placeholder="20대"
+  wrapperStyle={{ marginBottom: 24, paddingHorizontal: 16 }}
+/>
+
+// ✅ 올바른 사용 2: 특정 화면에서만 예외적으로 박스/글자 디자인 변경
+<Input
+  label="특수 입력창"
+  variant="primary"
+  containerStyle={{ backgroundColor: "#000", borderColor: "#333" }} // 박스 스타일 덮어쓰기
+  textStyle={{ color: "yellow", fontWeight: "bold" }} // 글자 스타일 덮어쓰기
+/>
+```
+
+## 참고
+
+- 컴포넌트 내부(글자, 빈 공간 등) 어디를 터치해도 자동으로 <TextInput>으로 포커스가 이동하도록 설계되어 있습니다.
+- Platform.select 최적화가 적용되어 있습니다.
+- 안드로이드 환경의 텍스트 수직 쏠림 현상을 방지하기 위해 paddingVertical: 0 처리가 포함되어 있습니다.

--- a/src/components/common/button/Button.styles.ts
+++ b/src/components/common/button/Button.styles.ts
@@ -1,0 +1,161 @@
+import { StyleSheet, ViewStyle, TextStyle, Platform } from "react-native";
+
+import { theme } from "@/src/constants";
+
+export type VariantType =
+  | "primary"
+  | "outline"
+  | "outlinePrimary"
+  | "neutral"
+  | "text"
+  | "textPrimary";
+
+export type SizeType = "xs" | "sm" | "md" | "lg" | "xl";
+
+export const wrapperVariants: Record<VariantType, ViewStyle> =
+  StyleSheet.create({
+    primary: {
+      backgroundColor: theme.colors.main,
+      borderColor: "transparent",
+      borderWidth: 1,
+    },
+    outline: {
+      backgroundColor: "transparent",
+      borderColor: theme.colors.gray200,
+      borderWidth: 1,
+    },
+    outlinePrimary: {
+      backgroundColor: "transparent",
+      borderColor: theme.colors.main,
+      borderWidth: 1,
+    },
+    neutral: {
+      backgroundColor: theme.colors.gray200,
+      borderColor: "transparent",
+      borderWidth: 1,
+    },
+    text: {
+      backgroundColor: "transparent",
+      borderColor: "transparent",
+      borderWidth: 1,
+    },
+    textPrimary: {
+      backgroundColor: "transparent",
+      borderColor: "transparent",
+      borderWidth: 1,
+    },
+  });
+
+export const textVariants: Record<VariantType, TextStyle> = StyleSheet.create({
+  primary: { color: theme.colors.white },
+  outline: { color: theme.colors.text },
+  outlinePrimary: { color: theme.colors.main },
+  neutral: { color: theme.colors.text },
+  text: { color: theme.colors.gray400 },
+  textPrimary: { color: theme.colors.main },
+});
+
+export const wrapperSizes: Record<SizeType, ViewStyle> = StyleSheet.create({
+  xs: { height: 36, paddingHorizontal: 10, borderRadius: 10 },
+  sm: { height: 40, paddingHorizontal: 14, borderRadius: 10 },
+  md: { height: 46, paddingHorizontal: 43, borderRadius: 14 },
+  lg: { height: 56, paddingHorizontal: 16, borderRadius: 12 },
+  xl: {
+    height: 96,
+    paddingHorizontal: 24,
+    borderRadius: 16,
+    ...Platform.select({
+      ios: {
+        shadowColor: theme.colors.black,
+        shadowOffset: { width: 0, height: 10 },
+        shadowOpacity: 0.1,
+        shadowRadius: 15,
+      },
+      android: {
+        elevation: 6,
+      },
+    }),
+  },
+});
+
+export const wrapperText: Record<SizeType, TextStyle> = StyleSheet.create({
+  xs: { fontSize: 12 },
+  sm: { fontSize: 14 },
+  md: { fontSize: 16 },
+  lg: { fontSize: 18 },
+  xl: { fontSize: 20 },
+});
+
+export const disabledWrapperVariants: Record<VariantType, ViewStyle> =
+  StyleSheet.create({
+    primary: {
+      backgroundColor: theme.colors.gray300,
+      borderColor: "transparent",
+    },
+    neutral: {
+      backgroundColor: theme.colors.gray100,
+      borderColor: "transparent",
+    },
+
+    outline: {
+      backgroundColor: "transparent",
+      borderColor: theme.colors.gray300,
+    },
+    outlinePrimary: {
+      backgroundColor: "transparent",
+      borderColor: theme.colors.gray300,
+    },
+
+    // 텍스트 버튼 (배경, 테두리 모두 투명하게 유지)
+    text: { backgroundColor: "transparent", borderColor: "transparent" },
+    textPrimary: { backgroundColor: "transparent", borderColor: "transparent" },
+  });
+
+export const buttonStyles = StyleSheet.create({
+  wrapper: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    alignSelf: "flex-start", // 내용물 크기만큼만 차지하게 함
+  },
+
+  text: {
+    fontWeight: "600",
+    textAlign: "center",
+    lineHeight: Platform.OS === "android" ? undefined : 0, // line-height 같은 효과
+  },
+
+  iconWrapper: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+
+  // 아이콘만 있는 버튼 (iconOnly={true} 일 때)
+  iconOnly: {
+    paddingHorizontal: 0,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+
+  // 완전히 둥근 버튼 (rounded={true} 일 때)
+  rounded: {
+    borderRadius: 9999,
+  },
+
+  // 선택된 상태 (isSelected={true} 일 때)
+  selected: {
+    borderWidth: 1,
+    borderColor: theme.colors.main,
+    backgroundColor: "transparent",
+  },
+
+  selectedText: {
+    color: theme.colors.main,
+    fontWeight: "700",
+  },
+
+  disabledText: {
+    color: theme.colors.gray400,
+  },
+});

--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -1,0 +1,113 @@
+import React, { forwardRef } from "react";
+import {
+  View,
+  Text,
+  Pressable,
+  PressableProps,
+  StyleProp,
+  ViewStyle,
+  TextStyle,
+} from "react-native";
+
+import {
+  SizeType,
+  VariantType,
+  buttonStyles,
+  disabledWrapperVariants,
+  textVariants,
+  wrapperSizes,
+  wrapperText,
+  wrapperVariants,
+} from "./Button.styles";
+
+interface ButtonProps extends PressableProps {
+  variant?: VariantType;
+  size?: SizeType;
+  fullWidth?: boolean;
+  flex?: boolean | number;
+  iconOnly?: boolean;
+  rounded?: boolean;
+  isSelected?: boolean;
+  startIcon?: React.ReactNode;
+  endIcon?: React.ReactNode;
+  children?: React.ReactNode;
+
+  wrapperStyle?: StyleProp<ViewStyle>;
+  textStyle?: StyleProp<TextStyle>;
+}
+
+export const Button = forwardRef<View, ButtonProps>(
+  (
+    {
+      variant = "primary",
+      size = "lg",
+      fullWidth = false,
+      iconOnly = false,
+      rounded = false,
+      isSelected = false,
+      disabled,
+      startIcon,
+      endIcon,
+      wrapperStyle,
+      textStyle,
+      children,
+      flex,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <Pressable
+        ref={ref}
+        disabled={disabled}
+        {...props}
+        style={({ pressed }) => [
+          buttonStyles.wrapper,
+          wrapperSizes[size],
+          wrapperVariants[variant],
+          fullWidth && { width: "100%", alignSelf: "auto" },
+
+          flex
+            ? { flex: typeof flex === "number" ? flex : 1, alignSelf: "auto" }
+            : undefined,
+
+          iconOnly && [
+            buttonStyles.iconOnly,
+            { width: wrapperSizes[size].height },
+          ],
+
+          rounded && buttonStyles.rounded,
+          isSelected && buttonStyles.selected,
+
+          pressed && { opacity: 0.8 },
+          disabled && disabledWrapperVariants[variant],
+          wrapperStyle,
+        ]}
+      >
+        {startIcon && <View style={buttonStyles.iconWrapper}>{startIcon}</View>}
+
+        {children &&
+          (iconOnly ? (
+            <View style={buttonStyles.iconWrapper}>{children}</View>
+          ) : (
+            <Text
+              style={[
+                buttonStyles.text,
+                wrapperText[size],
+                textVariants[variant],
+                disabled && buttonStyles.disabledText,
+                isSelected && buttonStyles.selectedText,
+                textStyle,
+              ]}
+            >
+              {children}
+            </Text>
+          ))}
+
+        {endIcon && <View style={buttonStyles.iconWrapper}>{endIcon}</View>}
+      </Pressable>
+    );
+  },
+);
+
+Button.displayName = "Button";

--- a/src/components/common/button/README.md
+++ b/src/components/common/button/README.md
@@ -1,0 +1,107 @@
+# Button
+
+앱 전반에서 사용되는 공통 버튼 컴포넌트입니다. `Pressable` 기반이며 6가지 디자인 타입(Variant), 5가지 크기(Size), 아이콘 배치, 그리고 다양한 상태(Disabled, Selected)를 지원합니다. 스타일은 `@/src/constants`의 `theme` 토큰을 기반으로 합니다.
+
+> 💡 **아이콘 전용 버튼**이 필요한 경우, 별도의 뷰(View) 조작 없이 `iconOnly` 프롭을 사용하여 완벽한 정사각형 버튼을 쉽게 구현할 수 있습니다.
+
+## Import
+
+```tsx
+import { Button } from "@/src/components/common/Button";
+import type {
+  VariantType,
+  SizeType,
+} from "@/src/components/common/Button/Button.styles";
+```
+
+## Props
+
+| Prop             | 타입                                                                                           | 기본값      | 설명                                                                                      |
+| ---------------- | ---------------------------------------------------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------- |
+| **variant**      | `"primary"` \| `"outline"` \| `"outlinePrimary"` \| `"neutral"` \| `"text"` \| `"textPrimary"` | `"primary"` | 버튼의 시각적 디자인 타입                                                                 |
+| **size**         | `"xs"` \| `"sm"` \| `"md"` \| `"lg"` \| `"xl"`                                                 | `"lg"`      | 버튼의 높이, 좌우 패딩 및 폰트 크기                                                       |
+| **fullWidth**    | `boolean`                                                                                      | `false`     | `true` 시 너비를 100%로 채움                                                              |
+| **flex**         | `boolean` \| `number`                                                                          | -           | 부모 컨테이너 내에서 flex 비율 조절 (`true` 입력 시 `flex: 1`)                            |
+| **iconOnly**     | `boolean`                                                                                      | `false`     | `true` 시 패딩을 없애고 높이(height)와 너비(width)를 동일하게 맞춰 **정사각형 형태** 유지 |
+| **rounded**      | `boolean`                                                                                      | `false`     | `true` 시 모서리를 완전히 둥글게 처리 (`borderRadius: 9999`)                              |
+| **isSelected**   | `boolean`                                                                                      | `false`     | `true` 시 선택된 상태 표시 (메인 컬러 테두리 및 Bold 텍스트)                              |
+| **disabled**     | `boolean`                                                                                      | `false`     | `true` 시 비활성화 상태 적용 (터치 차단 및 `variant`별 회색조 스타일 자동 적용)           |
+| **startIcon**    | `React.ReactNode`                                                                              | -           | 텍스트 좌측에 배치할 아이콘 (SVG 컴포넌트 등)                                             |
+| **endIcon**      | `React.ReactNode`                                                                              | -           | 텍스트 우측에 배치할 아이콘                                                               |
+| **children**     | `React.ReactNode`                                                                              | -           | 버튼 내부 텍스트 (또는 `iconOnly` 시 내부 아이콘)                                         |
+| **wrapperStyle** | `StyleProp<ViewStyle>`                                                                         | -           | **최상위 래퍼(Pressable) 스타일** (주로 외부 여백 `margin` 조절 시 사용)                  |
+| **textStyle**    | `StyleProp<TextStyle>`                                                                         | -           | **내부 텍스트 스타일** (글자색, 폰트 등 예외적 덮어쓰기 용도)                             |
+
+_(그 외 `onPress` 등 React Native의 기본 `PressableProps`를 모두 지원합니다.)_
+
+## 사용 예시
+
+```tsx
+import { Button } from "@/src/components/common/Button";
+import { Ionicons } from "@expo/vector-icons"; // 예시 아이콘
+
+// 1) 기본 사용 (primary, lg 사이즈)
+<Button onPress={handleSubmit}>다음으로</Button>
+
+// 2) 다양한 Variant 적용
+<Button variant="outline">취소</Button>
+<Button variant="neutral">나중에 하기</Button>
+<Button variant="textPrimary">건너뛰기</Button>
+
+// 3) 크기 조절 (xs ~ xl)
+<Button size="sm">평가하기</Button>
+<Button size="xl" fullWidth>모임 개설하기</Button>
+
+// 4) 좌우 아이콘 배치 (startIcon / endIcon)
+<Button
+  variant="primary"
+  startIcon={<Ionicons name="star" size={20} color="white" />}
+>
+  리뷰 남기기
+</Button>
+
+<Button
+  variant="text"
+  endIcon={<Ionicons name="chevron-forward" size={16} color="#333" />}
+>
+  더 보기
+</Button>
+
+// 5) 아이콘 전용 버튼 (iconOnly)
+// 💡 iconOnly 속성을 주면 텍스트 대신 children으로 전달된 아이콘이 중앙에 배치됩니다.
+<Button variant="outline" size="md" iconOnly rounded>
+  <Ionicons name="heart" size={24} color="red" />
+</Button>
+
+// 6) 상태 적용 (Selected / Disabled)
+<Button variant="outline" isSelected>선택됨</Button>
+<Button variant="primary" disabled>입력 완료 시 활성화</Button>
+```
+
+## 커스텀 스타일 및 확장성
+
+기본적으로는 `variant`와 `size`를 사용하여 디자인 일관성을 유지합니다. 특정 화면에서만 **예외적으로 외부 여백(margin)을 주거나 폰트를 변경해야 할 경우**, 아래 프롭을 통해 기본 스타일을 덮어쓸 수 있습니다.
+
+- `wrapperStyle`: 최상위 컨테이너 레이아웃 제어 (외부 여백 `margin`, 테두리 등 덮어쓰기)
+- `textStyle`: 내부 텍스트 디자인 제어 (`fontSize`, `color` 등 예외 적용)
+
+```tsx
+// ❌ 잘못된 사용: 컴포넌트에 기본 style 프롭 주입 불가 (에러 발생 가능)
+<Button style={{ marginTop: 20 }}>확인</Button>
+
+// ✅ 올바른 사용 1: wrapperStyle을 통한 외부 레이아웃 제어
+<Button wrapperStyle={{ marginTop: 24, marginBottom: 12 }}>
+  확인
+</Button>
+
+// ✅ 올바른 사용 2: 특정 텍스트 컬러 예외 처리
+<Button variant="primary" textStyle={{ color: "#FFFFCC" }}>
+  노란색 글씨 버튼
+</Button>
+```
+
+## 참고
+
+- 버튼을 터치(Press)할 때 기본적으로 `opacity: 0.8` 효과가 적용되어 있어, 웹의 `:active` 나 `:hover` 와 유사한 눌림 피드백을 제공합니다.
+- `size="xl"` 인 경우, OS(iOS/Android)에 맞춘 그림자(Shadow/Elevation) 효과가 자동으로 적용되어 있습니다.
+- `disabled` 활성화 시 단순히 투명도만 변하는 것이 아니라, `variant` 타입(꽉 찬 버튼, 테두리 버튼 등)에 맞춰 최적화된 회색조 디자인(`gray300`, `gray400` 등)이 자동으로 매핑됩니다.


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
<!-- 아직 완전 해결이 아닌 경우 `partially fixes #번호` 사용 -->
- close #4 

**1. Input 컴포넌트**
  - **3가지 Variant & Size 지원** (`primary`, `neutral`, `underline` / `sm`, `md`, `lg`)
  - **상태별 동적 스타일링 처리 (Focus, Error, Disabled)**
    - 모바일 환경에 맞춰 내부 `useState`를 활용해 포커스 상태(`isFocused`) 관리 (웹의 `:focus-within` 대체)
    - 에러 발생 시(`errorMessage`) 테두리 색상 우선 변경 처리
    - `underline` 타입의 경우 포커스/에러 시 전체 박스가 아닌 하단 선(`borderBottom`)만 색상이 변하도록 분기 처리 적용

**2. Button 컴포넌트**
  - **6가지 Variant & 5가지 Size 지원** (`primary`, `outline`, `neutral` 등 / `xs` ~ `xl`)
  - **상태별 정교한 스타일링 (Pressed, Selected, Disabled)**
    - 웹의 `:hover`/`:active`를 `Pressable`의 `pressed` 투명도(`opacity: 0.8`) 로직으로 자연스럽게 대체
    - `isSelected` 활성화 시 메인 컬러 테두리 및 Bold 텍스트 전환
    - `disabled` 시 단순 덮어쓰기가 아닌, Variant 특성(Solid, Outline, Text)에 맞춘 전용 회색조(`disabledWrapperVariants`) 매핑 로직 적용
  - **아이콘 및 레이아웃 지원**
    - `startIcon`, `endIcon` 지원 및 간격(`gap`) 자동 정렬
    - `iconOnly` 프롭 사용 시, 텍스트 렌더링을 안전하게 차단하고 사이즈에 맞춘 완벽한 정사각형 형태 렌더링 지원

**3. 공통 사항 (DX 및 확장성)**
  - `wrapperStyle`, `textStyle`(`inputStyle`) 등의 프롭을 열어두어 특정 화면의 예외적인 디자인 요구사항(외부 여백, 특수 컬러 등) 대응 가능
  - 개발자 경험(DX) 향상을 위해 컴포넌트별 사용법과 규칙을 명시한 `README.md` 문서화 완료

## 🖼 스크린샷(UI 변경시)
## 🙏 Question & PR point
- **[Input] 포커스 상태 관리 로직 (Lifting State Down)**
  - 폼 데이터(value)는 부모가 관리하지만, 순수 UI 상태인 테두리 색상 변경(`isFocused`)은 부모 컴포넌트의 보일러플레이트를 줄이기 위해 `Input` 컴포넌트 내부에서 `useState`로 캡슐화했습니다. 외부에서 주입한 `onFocus`, `onBlur`도 내부 이벤트와 함께 정상적으로 호출되도록 오버라이딩 해두었습니다.
- **[Button] Disabled 디자인 컨셉 및 분기 처리**
  - 웹에서는 `opacity: 0.5`로만 비활성화를 처리했으나, 모바일 UX의 명확성(Affordance)을 높이기 위해 명시적인 회색(`gray300` 등)을 사용하도록 디자인을 개선했습니다. 
  - 단, 무작정 회색을 덮어씌우면 Outline이나 Text 버튼이 시커멓게 칠해지는 문제가 있어, `disabledWrapperVariants`를 별도로 분리하여 각 형태에 맞게 비활성화되도록 설계했습니다. 디자인적으로도 기존 의도와 잘 맞는지 리뷰 부탁드립니다.
- **[Button] Props 네이밍 일관성 및 타입 안정성**
  - 텍스트 스타일 덮어쓰기 프롭을 `buttonStyle`에서 `textStyle`로 명명하여, `StyleProp<TextStyle>` 타입과의 의미적 일관성을 높이고 다른 개발자의 잘못된 사용(레이아웃 스타일 주입 등)을 방지했습니다.
- **접근성(Accessibility) 관련 논의 사항**
  - 현재 MVP 단계의 빠른 가설 검증과 모바일 최우선 런칭을 위해, 웹용 아웃라인 제거 코드 및 스크린 리더(`accessibilityLabel` 등) 속성은 이번 PR에서 의도적으로 제외했습니다. 추후 고도화 단계에서 공통 컴포넌트 레벨에 일괄 적용할 예정입니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
