### PR TITLE
[FEAT] 러닝 매칭 검색 페이지

### DIFF
--- a/app/(main)/search-result.tsx
+++ b/app/(main)/search-result.tsx
@@ -1,0 +1,33 @@
+import { StyleSheet, Text, View } from "react-native";
+
+import { colors, fontSizes, fontWeights, spacing } from "@/src/constants";
+
+export default function SearchResultScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>러닝 코스 검색 결과 페이지</Text>
+      <Text style={styles.hint}>
+        `/session-result`에 대응하는 화면입니다. (준비 중)
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: spacing.lg,
+    backgroundColor: colors.bgSecondary,
+    justifyContent: "center",
+  },
+  title: {
+    fontSize: fontSizes.xl,
+    fontWeight: fontWeights.bold,
+    color: colors.text,
+    marginBottom: spacing.sm,
+  },
+  hint: {
+    fontSize: fontSizes.sm,
+    color: colors.textSecondary,
+  },
+});

--- a/app/(main)/search.tsx
+++ b/app/(main)/search.tsx
@@ -1,14 +1,162 @@
-import { StyleSheet, Text, View } from "react-native";
+import * as Location from "expo-location";
+import { useRouter } from "expo-router";
+import { useState, useEffect, useRef } from "react";
+import { View, Text, StyleSheet, Pressable, Alert } from "react-native";
 
-import { colors, fontSizes, fontWeights, spacing } from "@/src/constants";
+import SearchSvg from "../../src/assets/icon/search.svg";
+
+import {
+  getMapMarkers,
+  getSessionDetail,
+} from "@/src/api/search/searchApi.index";
+import { Input } from "@/src/components/common/Input/Input";
+import Chip from "@/src/components/common/chip";
+import { NaverMapComponent } from "@/src/components/common/map/NaverMapComponent";
+import { BottomOverlay } from "@/src/components/search/BottomOverLay";
+import {
+  RunningItem,
+  GetMarkersParams,
+  MapMarkerResponse,
+} from "@/src/types/api/search";
+
+const MOCK_FILTERS = ["3km 이내", "오늘", "10km 이상"];
 
 export default function SearchScreen() {
+  const router = useRouter();
+
+  const [selectedCourse, setSelectedCourse] = useState<RunningItem | null>(
+    null,
+  );
+  const [camera, setCamera] = useState<{
+    latitude: number;
+    longitude: number;
+    zoom: number;
+  } | null>(null);
+
+  const [bounds, setBounds] = useState<GetMarkersParams | null>(null);
+
+  const [markers, setMarkers] = useState<MapMarkerResponse[]>([]);
+
+  const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+  //디바운싱 타이머
+  useEffect(() => {
+    if (!bounds) return;
+
+    const fetchMarkers = async () => {
+      try {
+        const data = await getMapMarkers(bounds);
+        setMarkers((prevMarkers) => {
+          const markerMap = new Map(prevMarkers.map((m) => [m.id, m]));
+
+          data.forEach((m) => markerMap.set(m.id, m));
+
+          return Array.from(markerMap.values());
+        });
+      } catch (error) {
+        console.error("마커 가져오기 실패:", error);
+      }
+    };
+
+    fetchMarkers();
+  }, [bounds]);
+
+  // 현재 위치로 지도 초기 위치 로딩
+  useEffect(() => {
+    const fetchCurrentLocation = async () => {
+      const { status } = await Location.requestForegroundPermissionsAsync();
+      if (status != "granted") {
+        Alert.alert(
+          "위치 권한 필요",
+          "위치 권한이 없어 기본 지도를 표시합니다.\n상단 검색창을 통해 원하는 러닝 지역을 찾아보세요!",
+          [{ text: "확인" }],
+        );
+        setCamera({
+          // 위치 로딩 실패 시 대한민국 정중앙 부근의 좌표를 넣어서 전국이 보이게 유도
+          latitude: 36.5,
+          longitude: 127.5,
+          zoom: 6, //  6으로 줌 아웃
+        });
+        return;
+      }
+
+      const location = await Location.getCurrentPositionAsync({});
+
+      setCamera({
+        latitude: location.coords.latitude,
+        longitude: location.coords.longitude,
+        zoom: 14,
+      });
+    };
+
+    fetchCurrentLocation();
+  }, []);
+
+  if (camera === null) {
+    return (
+      <View style={styles.findLocation}>
+        <Text>현재 위치를 찾고 있습니다...</Text>
+      </View>
+    );
+  }
+
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>탐색</Text>
-      <Text style={styles.hint}>
-        `/search`에 대응하는 화면입니다. (준비 중)
-      </Text>
+      <NaverMapComponent
+        camera={camera}
+        markers={markers.map((course) => ({
+          id: course.id,
+          longitude: course.x,
+          latitude: course.y,
+          onTap: async () => {
+            try {
+              const data = await getSessionDetail(course.id);
+              setSelectedCourse(data);
+            } catch (error) {
+              console.error("상세정보 가져오기 실패", error);
+            }
+          },
+        }))}
+        onMapTap={() => setSelectedCourse(null)}
+        isScrollGesturesEnabled
+        onCameraChanged={(e) => {
+          if (e.reason !== "Gesture") return; // 유저가 드래그한 게 아니라면 무시
+
+          // 유저가 계속 드래그 중이라면, 기존에 걸어둔 예약(타이머)을 취소
+          if (debounceTimerRef.current) {
+            clearTimeout(debounceTimerRef.current);
+          }
+
+          // 드래그가 멈추고 0.2초가 지나면 한 번만 State를 업데이트
+          debounceTimerRef.current = setTimeout(() => {
+            setBounds({
+              leftX: e.region.longitude,
+              leftY: e.region.latitude,
+              rightX: e.region.longitude + e.region.longitudeDelta,
+              rightY: e.region.latitude + e.region.latitudeDelta,
+            });
+          }, 200); // 200ms 디바운스
+        }}
+      />
+      <View style={styles.topOverlay}>
+        {/* 실제 검색은 search-result 페이지에서 실행 */}
+        <Pressable onPress={() => router.push("/(main)/search-result")}>
+          <View pointerEvents="none">
+            <Input
+              placeholder="지역 또는 크루 검색"
+              startIcon={<SearchSvg />}
+              editable={false}
+            />
+          </View>
+        </Pressable>
+
+        <View style={styles.chipContainer}>
+          {MOCK_FILTERS.map((text, index) => (
+            <Chip key={index} label={text} />
+          ))}
+        </View>
+      </View>
+      {selectedCourse && <BottomOverlay {...selectedCourse} />}
     </View>
   );
 }
@@ -16,18 +164,21 @@ export default function SearchScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    padding: spacing.lg,
-    backgroundColor: colors.bgSecondary,
-    justifyContent: "center",
   },
-  title: {
-    fontSize: fontSizes.xl,
-    fontWeight: fontWeights.bold,
-    color: colors.text,
-    marginBottom: spacing.sm,
+
+  topOverlay: {
+    position: "absolute",
+    left: 20,
+    right: 20,
+    top: 40,
+    gap: 12,
   },
-  hint: {
-    fontSize: fontSizes.sm,
-    color: colors.textSecondary,
+
+  chipContainer: {
+    flexDirection: "row",
+    gap: 8,
+    flexWrap: "wrap",
   },
+
+  findLocation: { flex: 1, justifyContent: "center", alignItems: "center" },
 });

--- a/app/(main)/session-detail.tsx
+++ b/app/(main)/session-detail.tsx
@@ -1,0 +1,33 @@
+import { StyleSheet, Text, View } from "react-native";
+
+import { colors, fontSizes, fontWeights, spacing } from "@/src/constants";
+
+export default function SessionDetailScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>러닝 코스 상세 페이지</Text>
+      <Text style={styles.hint}>
+        `/session-detail`에 대응하는 화면입니다. (준비 중)
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: spacing.lg,
+    backgroundColor: colors.bgSecondary,
+    justifyContent: "center",
+  },
+  title: {
+    fontSize: fontSizes.xl,
+    fontWeight: fontWeights.bold,
+    color: colors.text,
+    marginBottom: spacing.sm,
+  },
+  hint: {
+    fontSize: fontSizes.sm,
+    color: colors.textSecondary,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "expo-build-properties": "~1.0.10",
         "expo-constants": "~18.0.13",
         "expo-linking": "~8.0.11",
+        "expo-location": "~19.0.8",
         "expo-router": "~6.0.23",
         "expo-secure-store": "~15.0.8",
         "expo-status-bar": "~3.0.9",
@@ -6787,6 +6788,15 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-location": {
+      "version": "19.0.8",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-19.0.8.tgz",
+      "integrity": "sha512-H/FI75VuJ1coodJbbMu82pf+Zjess8X8Xkiv9Bv58ZgPKS/2ztjC1YO1/XMcGz7+s9DrbLuMIw22dFuP4HqneA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "expo-build-properties": "~1.0.10",
     "expo-constants": "~18.0.13",
     "expo-linking": "~8.0.11",
+    "expo-location": "~19.0.8",
     "expo-router": "~6.0.23",
     "expo-secure-store": "~15.0.8",
     "expo-status-bar": "~3.0.9",

--- a/src/api/search/searchApi.index.ts
+++ b/src/api/search/searchApi.index.ts
@@ -1,0 +1,26 @@
+import {
+  getMapMarkers as realgetMapMarkers,
+  getSessionDetail as realgetSessionDetail,
+} from "@/src/api/search/searchApi";
+import {
+  getMapMarkers as mockgetMapMarkers,
+  getSessionDetail as mockgetSessionDetail,
+} from "@/src/api/search/searchApi.mock";
+
+const isMock = process.env.EXPO_PUBLIC_USE_MOCK === "true";
+
+/**
+ * 지도 영역 내 마커 검색
+ * @param params - 마커 검색을 위한 지도의 경계 좌표 (leftX, leftY, rightX, rightY)
+ * @returns 지도 위에 표시할 마커 목록 (MapMarkerResponse 배열)
+ */
+export const getMapMarkers = isMock ? mockgetMapMarkers : realgetMapMarkers;
+
+/**
+ * 러닝 세션 상세 정보 조회
+ * @param sessionId - 조회할 러닝 세션의 고유 ID
+ * @returns 러닝 세션의 상세 정보 (RunningItem)
+ */
+export const getSessionDetail = isMock
+  ? mockgetSessionDetail
+  : realgetSessionDetail;

--- a/src/api/search/searchApi.mock.ts
+++ b/src/api/search/searchApi.mock.ts
@@ -1,0 +1,36 @@
+import type {
+  MapMarkerResponse,
+  RunningItem,
+  GetMarkersParams,
+} from "@/src/types/api/search";
+
+/**
+ * 1. 지도 마커 검색
+ */
+export const getMapMarkers = async (
+  _params: GetMarkersParams,
+): Promise<MapMarkerResponse[]> => {
+  return [
+    { id: 201, title: "여의도 한강공원 나이트런", x: 126.9333, y: 37.5271 },
+    { id: 202, title: "남산 북측순환로 업힐 훈련", x: 126.9897, y: 37.5532 },
+    { id: 203, title: "올림픽공원 주말 모닝 LSD", x: 127.1214, y: 37.5206 },
+  ];
+};
+
+/**
+ * 2. 세션 요약 정보
+ */
+export const getSessionDetail = async (
+  sessionId: number,
+): Promise<RunningItem> => {
+  return {
+    id: sessionId,
+    title: "여의도 한강공원 나이트런",
+    startAt: "2026-05-08T11:00:00.000Z",
+    locationName: "서울시 영등포구 여의도 한강공원",
+    targetDistanceKm: 10,
+    avgPaceSec: 300,
+    genderPolicy: "ALL",
+    runType: "RECOVERY",
+  };
+};

--- a/src/api/search/searchApi.ts
+++ b/src/api/search/searchApi.ts
@@ -1,0 +1,23 @@
+import { axiosInstance } from "@/src/api/axiosInstance";
+import {
+  GetMarkersParams,
+  MapMarkerResponse,
+  RunningItem,
+} from "@/src/types/api/search";
+
+export const getMapMarkers = async (
+  params: GetMarkersParams,
+): Promise<MapMarkerResponse[]> => {
+  const response = await axiosInstance.get("/sessions/search/markers", {
+    params: params,
+  });
+
+  return response.data;
+};
+
+export const getSessionDetail = async (
+  sessionId: number,
+): Promise<RunningItem> => {
+  const response = await axiosInstance.get(`/sessions/${sessionId}/summary`);
+  return response.data;
+};

--- a/src/assets/icon/search.svg
+++ b/src/assets/icon/search.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.16454 15.8296C12.8455 15.8296 15.8296 12.8455 15.8296 9.16454C15.8296 5.48355 12.8455 2.49951 9.16454 2.49951C5.48355 2.49951 2.49951 5.48355 2.49951 9.16454C2.49951 12.8455 5.48355 15.8296 9.16454 15.8296Z" stroke="#99A1AF" stroke-width="1.66626" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17.5903 17.5859L14.0078 14.0034" stroke="#99A1AF" stroke-width="1.66626" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/common/map/NaverMapComponent.tsx
+++ b/src/components/common/map/NaverMapComponent.tsx
@@ -4,6 +4,9 @@ import {
   NaverMapPathOverlay,
   MapImageProp,
   NaverMapViewRef,
+  Camera,
+  CameraChangeReason,
+  Region,
 } from "@mj-studio/react-native-naver-map";
 import { useCallback, forwardRef, memo } from "react";
 import { StyleSheet, View, ViewStyle } from "react-native";
@@ -31,9 +34,15 @@ interface NaverMapComponentProps {
 
   // UI 및 기능 설정
   showLocationButton?: boolean; // 현재 위치로 가는 버튼 표시 여부
-  isCreateMode?: boolean; // true면 코스 그리기 모드
   isShowZoomControls?: boolean;
   onMapTap?: (latitude: number, longitude: number) => void;
+
+  onCameraChanged?: (
+    params: Camera & {
+      reason: CameraChangeReason;
+      region: Region;
+    },
+  ) => void;
 
   // 커뮤니티용 정적 지도 설정
   // 스크롤뷰 안에서 지도가 움직이지 않게 고정할 때 사용
@@ -54,9 +63,9 @@ export const NaverMapComponent = memo(
         markers = [],
         routePath,
         showLocationButton = false,
-        isCreateMode = false,
         isShowZoomControls = false,
         onMapTap,
+        onCameraChanged,
         isScrollGesturesEnabled = false,
         isZoomGesturesEnabled = false,
         lineColor = theme.colors.main,
@@ -66,12 +75,11 @@ export const NaverMapComponent = memo(
     ) => {
       const handleMapTap = useCallback(
         (e: { latitude: number; longitude: number }) => {
-          //코스 생성 모드일 때만 부모에게 좌표 전달
-          if (isCreateMode && onMapTap) {
+          if (onMapTap) {
             onMapTap(e.latitude, e.longitude);
           }
         },
-        [isCreateMode, onMapTap],
+        [onMapTap],
       );
 
       return (
@@ -85,6 +93,7 @@ export const NaverMapComponent = memo(
             isZoomGesturesEnabled={isZoomGesturesEnabled}
             onTapMap={handleMapTap}
             isShowZoomControls={isShowZoomControls} // 기본 줌 버튼 숨기기
+            onCameraChanged={onCameraChanged}
           >
             {/* 마커 렌더링 */}
             {markers.map((marker) => (

--- a/src/components/search/BottomOverLay.tsx
+++ b/src/components/search/BottomOverLay.tsx
@@ -1,0 +1,130 @@
+import { useRouter } from "expo-router";
+import { View, Text, StyleSheet, Platform } from "react-native";
+
+import { Button } from "@/src/components/common/button/Button";
+import Chip from "@/src/components/common/chip";
+import { theme } from "@/src/constants";
+import { RunningItem } from "@/src/types/api/search";
+
+export function BottomOverlay({
+  id,
+  title,
+  startAt,
+  locationName,
+  targetDistanceKm,
+  avgPaceSec,
+  genderPolicy,
+  runType,
+}: RunningItem) {
+  const date = new Date(startAt);
+
+  const formatted = date.toLocaleDateString("ko-KR", {
+    hour: "numeric",
+    minute: "numeric",
+    hour12: true,
+  });
+
+  const paceMinte = Math.floor(avgPaceSec / 60);
+  const paceSecond = avgPaceSec % 60;
+  const paceFomatting = `${paceMinte}: ${paceSecond === 0 ? "00" : paceSecond}`;
+
+  const router = useRouter();
+
+  return (
+    <View style={styles.bottomOverlay}>
+      <View style={styles.titleContainer}>
+        <View style={styles.titleTextWrapper}>
+          <Text style={styles.titleText} numberOfLines={1}>
+            {title}
+          </Text>
+          <Text style={styles.subText}>{formatted}</Text>
+          <Text>{locationName}</Text>
+        </View>
+        <View>
+          <Button
+            onPress={() =>
+              router.push({
+                pathname: "/(main)/session-detail",
+                params: { id },
+              })
+            }
+          >
+            상세보기
+          </Button>
+        </View>
+      </View>
+
+      <View style={styles.infoContainer}>
+        <Text style={styles.infoText}>
+          {targetDistanceKm}km , 평균 페이스: {paceFomatting}km/h
+        </Text>
+        <View style={styles.chipContainer}>
+          <Chip color="secondary" label={genderPolicy} />
+          <Chip color="secondary" label={runType} />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  bottomOverlay: {
+    position: "absolute",
+    bottom: 40,
+    backgroundColor: theme.colors.bg,
+    borderRadius: theme.borderRadius.md,
+    padding: 20,
+    left: 20,
+    right: 20,
+    gap: 16,
+    ...Platform.select({
+      ios: {
+        shadowColor: theme.colors.black,
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.5,
+        shadowRadius: theme.borderRadius.md,
+      },
+      android: {
+        elevation: 8,
+      },
+    }),
+  },
+
+  titleContainer: {
+    flexDirection: "row",
+    gap: 12,
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+
+  titleTextWrapper: {
+    flex: 1,
+    gap: 4,
+  },
+
+  titleText: {
+    fontSize: theme.fontSizes.lg,
+    fontWeight: theme.fontWeights.bold,
+    color: theme.colors.text,
+  },
+
+  subText: {
+    fontSize: theme.fontSizes.sm,
+    color: theme.colors.gray500,
+  },
+
+  infoContainer: {
+    gap: 8,
+  },
+
+  infoText: {
+    fontSize: theme.fontSizes.sm,
+    color: theme.colors.gray500,
+  },
+
+  chipContainer: {
+    flexDirection: "row",
+    gap: 8,
+    flexWrap: "wrap", // 화면이 좁아 칩이 많아질 경우 밑으로 내려가도록 처리
+  },
+});

--- a/src/types/api/search.ts
+++ b/src/types/api/search.ts
@@ -1,0 +1,24 @@
+export interface GetMarkersParams {
+  leftX: number;
+  leftY: number;
+  rightX: number;
+  rightY: number;
+}
+
+export interface MapMarkerResponse {
+  id: number;
+  title: string;
+  x: number;
+  y: number;
+}
+
+export interface RunningItem {
+  id: number;
+  title: string;
+  startAt: string;
+  locationName: string;
+  targetDistanceKm: number;
+  avgPaceSec: number;
+  genderPolicy: string;
+  runType: string;
+}

--- a/src/types/search/search.ts
+++ b/src/types/search/search.ts
@@ -1,0 +1,13 @@
+// 성별 정책 Enum
+export enum GenderPolicy {
+  MALE_ONLY = "남성",
+  FEMALE_ONLY = "여성",
+  MIXED = "남녀무관",
+}
+
+// 러닝 타입 Enum
+export enum RunType {
+  RECOVERY = "리커버리런",
+  INTERVAL = "인터벌",
+  LSD = "LSD",
+}


### PR DESCRIPTION
## 📣 Related Issue
- close #13 

## 📝 Summary
### 📍 지도 드래그 기반 러닝 세션 탐색 기능 구현
* **성능 최적화**: `onCameraChanged` 이벤트에 **200ms 디바운싱**을 적용하여 불필요한 API 호출 및 렌더링 과부하를 방지했습니다.
* **마커 누적 로직**: `Map` 객체를 활용하여 지도를 이동해도 기존 마커가 유지되도록 구현했습니다. 중복 데이터는 자동으로 제거되어 부드러운 사용자 경험(UX)을 제공합니다.

### 🛡️ 위치 권한 핸들링 및 예외 처리
* `expo-location`을 이용해 현재 위치를 로딩합니다.
* 권한 거부 시 유저에게 **Alert**으로 안내한 뒤, **전국 지도(줌 레벨 6)**를 보여주는 폴백(Fallback) 처리를 통해 서비스 이용 흐름이 끊기지 않도록 했습니다.

### 🗺️ 내비게이션 및 UX 개선
* **검색 흐름**: 메인 화면의 검색창은 실제 입력창이 아닌 가짜 검색창(Fake Input)으로 구현되었습니다. 클릭 시 타이핑을 위한 검색 결과 페이지(search-result)로 즉시 이동하여 유저가 검색에 집중할 수 있도록 유도했습니다.
* **페이지 뼈대 구축**: `search-result`, `session-detail` 페이지의 뼈대(Skeleton)를 생성하고, 상세 페이지 진입 시 `id` 파라미터를 전달하는 로직을 연결했습니다.
* 

## 🖼 스크린샷
<img width="320" height="658" alt="스크린샷 2026-05-09 000730" src="https://github.com/user-attachments/assets/1bd0f9b4-0041-47a1-a6ae-9118ca424841" />

## 🙏 Question & PR point
* **디바운스 시간**: 현재 유저가 드래그를 멈춘 뒤 200ms 후에 마커를 요청합니다. 실제 기기에서 체감되는 반응 속도가 적절한지 리뷰 부탁드립니다.
* **마커 관리**: 현재는 기존 마커를 지우지 않고 `Map`으로 계속 누적합니다. 데이터가 방대해질 경우를 대비해 영역 밖의 마커를 정리하는 로직이 추가로 필요할지 의견 주시면 감사하겠습니다.
* **필터 데이터**: 상단 필터 칩은 현재 백엔드 미구현 상태로 임시 상수(`MOCK_FILTERS`)를 사용 중입니다.
### ⚙️ 환경 설정 및 의존성 추가
* **신규 패키지 설치**: 위치 정보 기능을 위해 `expo-location` 라이브러리를 추가했습니다.
* **로컬 업데이트 필요**: 이 브랜치를 pull 받으신 후 반드시 아래 명령어를 실행해 주세요.
  ```bash
  npm install

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
