### PR TITLE
[FIX] 상세 페이지 런타임 에러 해결 및 API 스펙 동기화

### DIFF
--- a/app/(main)/_layout.tsx
+++ b/app/(main)/_layout.tsx
@@ -84,6 +84,21 @@ export default function MainLayout() {
           headerLeft: () => <StackHeaderBack />,
         }}
       />
+      <Tabs.Screen
+        name="search-result"
+        options={{
+          href: null,
+          headerShown: false,
+        }}
+      />
+      <Tabs.Screen
+        name="session-detail"
+        options={{
+          href: null,
+          title: "상세 정보",
+          headerLeft: () => <StackHeaderBack />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(main)/search.tsx
+++ b/app/(main)/search.tsx
@@ -12,8 +12,10 @@ import {
 
 import SearchSvg from "../../src/assets/icon/search.svg";
 
-import { getMapMarkers } from "@/src/api/search/searchApi.index";
-import { getSessionDetail } from "@/src/api/session-detail/sessionDetailApi.index";
+import {
+  getMapMarkers,
+  getSessionSummary,
+} from "@/src/api/search/searchApi.index";
 import { Input } from "@/src/components/common/Input/Input";
 import Chip from "@/src/components/common/chip";
 import { NaverMapComponent } from "@/src/components/common/map/NaverMapComponent";
@@ -46,7 +48,7 @@ export default function SearchScreen() {
 
   const { data: selectedCourse, isFetching: isDetailLoading } = useQuery({
     queryKey: ["sessionDetail", selectedSessionId],
-    queryFn: () => getSessionDetail(selectedSessionId!),
+    queryFn: () => getSessionSummary(selectedSessionId!),
     enabled: !!selectedSessionId,
     staleTime: CACHE_TIME_5_MIN,
   });

--- a/app/(main)/session-detail.tsx
+++ b/app/(main)/session-detail.tsx
@@ -51,11 +51,16 @@ export default function SessionDetailScreen() {
   const genderInfo = GENDER_INFO[data.genderPolicy] || GENDER_INFO.MIXED;
   const runTypeInfo = RUN_TYPE_INFO[data.runType] || RUN_TYPE_INFO.LSD;
 
+  const routePolyline = (data.routePolyline ?? []).map((point) => ({
+    latitude: point.y,
+    longitude: point.x,
+  }));
+
   const initialCamera =
-    data.routePolyline.length > 0
+    routePolyline.length > 0
       ? {
-          latitude: data.routePolyline[0].latitude,
-          longitude: data.routePolyline[0].longitude,
+          latitude: routePolyline[0].latitude,
+          longitude: routePolyline[0].longitude,
           zoom: 14,
         }
       : { latitude: 37.5271, longitude: 126.9233, zoom: 14 };
@@ -70,7 +75,7 @@ export default function SessionDetailScreen() {
         <View style={styles.mapContainer}>
           <NaverMapComponent
             camera={initialCamera}
-            routePath={data.routePolyline}
+            routePath={routePolyline}
             isScrollGesturesEnabled={true}
             isZoomGesturesEnabled={true}
           />
@@ -152,7 +157,11 @@ export default function SessionDetailScreen() {
           <View style={styles.section}>
             <Text style={styles.sectionTitle}>호스트</Text>
             <View style={styles.hostProfile}>
-              <View style={styles.profileAvatarPlaceholder}>아이콘</View>
+              <View style={styles.profileAvatarPlaceholder}>
+                <Text style={styles.iconText}>
+                  {data.hostName ? data.hostName.slice(0, 1) : "?"}
+                </Text>
+              </View>
               <View style={styles.hostInfo}>
                 <Text style={styles.hostName}>{data.hostName}</Text>
                 <Chip
@@ -172,7 +181,7 @@ export default function SessionDetailScreen() {
             <View style={styles.participantList}>
               {data.participants?.slice(0, 3).map((participants, index) => (
                 <View key={index} style={styles.profileAvatarPlaceholder}>
-                  <Text style={styles.participantsText}>
+                  <Text style={styles.iconText}>
                     {participants.slice(0, 1)}
                   </Text>
                 </View>
@@ -185,10 +194,7 @@ export default function SessionDetailScreen() {
                   ]}
                 >
                   <Text
-                    style={[
-                      styles.participantsText,
-                      { color: colors.textSecondary },
-                    ]}
+                    style={[styles.iconText, { color: colors.textSecondary }]}
                   >
                     +{participants.length - 3}
                   </Text>

--- a/src/api/search/searchApi.index.ts
+++ b/src/api/search/searchApi.index.ts
@@ -1,10 +1,12 @@
 import {
   getMapMarkers as realgetMapMarkers,
   searchSessions as realSearchSessions,
+  getSessionSummary as realGetSessionSummary,
 } from "@/src/api/search/searchApi";
 import {
   getMapMarkers as mockgetMapMarkers,
   searchSessions as mockSearchSessions,
+  getSessionSummary as mockGetSessionSummary,
 } from "@/src/api/search/searchApi.mock";
 
 const isMock = process.env.EXPO_PUBLIC_USE_MOCK === "true";
@@ -22,3 +24,12 @@ export const getMapMarkers = isMock ? mockgetMapMarkers : realgetMapMarkers;
  * @returns 검색 조건에 맞는 러닝 세션 목록 및 페이징 정보 (RunningSearchResponse)
  */
 export const searchSessions = isMock ? mockSearchSessions : realSearchSessions;
+
+/**
+ * 러닝 세션 요약 정보 조회 (지도 바텀 시트용)
+ * @param sessionId - 조회할 러닝 세션의 고유 ID
+ * @returns 러닝 세션의 요약 정보
+ */
+export const getSessionSummary = isMock
+  ? mockGetSessionSummary
+  : realGetSessionSummary;

--- a/src/api/search/searchApi.mock.ts
+++ b/src/api/search/searchApi.mock.ts
@@ -68,6 +68,16 @@ export const DUMMY_DATA: RunningItem[] = [
   },
 ];
 
+export const getSessionSummary = async (sessionId: number) => {
+  await new Promise((resolve) => setTimeout(resolve, 300));
+
+  const baseData = DUMMY_DATA.find((item) => item.id === sessionId);
+  if (!baseData) {
+    throw new Error(`Session ID ${sessionId}를 찾을 수 없습니다.`);
+  }
+  return baseData;
+};
+
 export const searchSessions = async (params: {
   q: string;
   size: number;

--- a/src/api/search/searchApi.ts
+++ b/src/api/search/searchApi.ts
@@ -22,3 +22,8 @@ export const searchSessions = async (
   const response = await axiosInstance.get("/sessions/search", { params });
   return response.data;
 };
+
+export const getSessionSummary = async (sessionId: number) => {
+  const response = await axiosInstance.get(`/sessions/${sessionId}/summary`);
+  return response.data;
+};

--- a/src/api/session-detail/sessionDetailApi.mock.ts
+++ b/src/api/session-detail/sessionDetailApi.mock.ts
@@ -20,11 +20,11 @@ export const getSessionDetail = async (
     hostMannerTemp: 36.5,
     participants: ["이민수", "박지훈", "최민석"],
     routePolyline: [
-      { latitude: 37.5271, longitude: 126.9233 },
-      { latitude: 37.5285, longitude: 126.925 },
-      { latitude: 37.5292, longitude: 126.9275 },
-      { latitude: 37.5281, longitude: 126.9299 },
-      { latitude: 37.5265, longitude: 126.9288 },
+      { x: 126.9233, y: 37.5271 },
+      { x: 126.925, y: 37.5285 },
+      { x: 126.9275, y: 37.5292 },
+      { x: 126.9299, y: 37.5281 },
+      { x: 126.9288, y: 37.5265 },
     ],
   };
 };

--- a/src/api/session-detail/sessionDetailApi.ts
+++ b/src/api/session-detail/sessionDetailApi.ts
@@ -4,7 +4,7 @@ import { SessionDetailResponse } from "@/src/types/api/session-detail";
 export const getSessionDetail = async (
   sessionId: number,
 ): Promise<SessionDetailResponse> => {
-  const response = await axiosInstance.get(`/sessions/${sessionId}/summary`);
+  const response = await axiosInstance.get(`/sessions/${sessionId}`);
   return response.data;
 };
 

--- a/src/components/session-detail/SessionDetail.styles.ts
+++ b/src/components/session-detail/SessionDetail.styles.ts
@@ -101,9 +101,10 @@ export const SessionDetailStyles = StyleSheet.create({
     borderWidth: 1,
     borderColor: colors.bg,
   },
-  participantsText: {
+  iconText: {
     color: colors.white,
     fontSize: fontSizes.sm,
+    fontWeight: fontWeights.bold,
   },
   hostInfo: {
     gap: 4,

--- a/src/types/api/session-detail.ts
+++ b/src/types/api/session-detail.ts
@@ -1,8 +1,8 @@
 import type { RunningItem } from "./search";
 
 export interface RoutePoint {
-  latitude: number;
-  longitude: number;
+  x: number;
+  y: number;
 }
 
 export interface SessionDetailResponse extends RunningItem {


### PR DESCRIPTION
## 📣 Related Issue
- close #29 

## 📝 Summary
- **백엔드 명세 동기화:** `routePolyline` 데이터가 `latitude/longitude` 대신 `x/y`로 들어오는 명세 변경 사항을 반영하여 타입 및 파싱 로직을 수정했습니다.
- **API 도메인 분리:** 지도 바텀 시트용 요약 데이터(`getSessionSummary`)와 전체 상세 데이터(`getSessionDetail`) API를 분리하고, Mock 환경도 실제 환경과 동일하게 동기화했습니다.
- **런타임 에러 방어:** 상세 페이지 진입 시 데이터가 지연되거나 없을 때 발생하는 강제 종료(Crash)를 막기 위해 `?? []` 연산자로 방어 코드를 추가했습니다.
- **UI 개선:** 호스트 프로필의 플레이스홀더 텍스트("아이콘")를 `hostName`의 첫 글자(이니셜)가 나오도록 동적으로 변경했습니다.
- **탭바 버그 수정:** 메인 하단 탭바에 의도치 않게 노출되던 '상세 페이지', '검색 결과 페이지' 엑스박스 아이콘을 숨김 처리(`href: null`)했습니다.

## 🙏 Question & PR point
1. **API 도메인 분리 관점:** 기존에 상세 페이지 폴더에 있던 API 로직을, 사용처에 맞게 `search`(요약)와 `session-detail`(상세)로 분리했습니다. 도메인 분리 관점에서 이 아키텍처가 적절할지 리뷰 부탁드립니다
2. **방어적 프로그래밍:** `data.routePolyline ?? []` 처럼 런타임 에러를 방어하는 로직을 추가했습니다. 혹시 제가 놓친 다른 데이터 `undefined` 엣지 케이스가 있을지 봐주시면 감사하겠습니다.
3. **Expo Router 탭바 제어:** `app/(main)/_layout.tsx`에서 탭바 아이콘을 숨기기 위해 `href: null`을 사용했습니다. 현재 파일 기반 라우팅 구조에서 이 방식이 최선인지, 아니면 더 권장되는 패턴이 있는지 궁금합니다.
