### PR TITLE
Fix/#28 마이페이지 프로필 API 스펙 동기화 및 상태 관리/UX 개선

### DIFF
--- a/app/(main)/my-page.tsx
+++ b/app/(main)/my-page.tsx
@@ -36,6 +36,7 @@ import { useMyPageQueries } from "@/src/hooks/mypage/useMyPageQueries";
 
 export default function MyPageScreen() {
   const [isSettingsVisible, setSettingsVisible] = useState(false);
+  const [isManualRefreshing, setIsManualRefreshing] = useState(false);
   const queryClient = useQueryClient();
 
   const {
@@ -44,22 +45,31 @@ export default function MyPageScreen() {
     appliedRunsData,
     historyRunsData,
     isTotalLoading,
-    isRefetching,
     refetchAppliedRuns,
     refetchCreatedRuns,
     refetchHistoryRuns,
     refetchProfile,
+    isProfileError,
+    isCreatedRunsError,
+    isAppliedRunsError,
+    isHistoryRunsError,
+    isProfileFetching,
+    isCreatedRunsFetching,
+    isAppliedRunsFetching,
+    isHistoryRunsFetching,
   } = useMyPageQueries();
 
   const router = useRouter();
 
   const onRefresh = async () => {
+    setIsManualRefreshing(true);
     await Promise.all([
       refetchProfile(),
       refetchCreatedRuns(),
       refetchAppliedRuns(),
       refetchHistoryRuns(),
     ]);
+    setIsManualRefreshing(false);
   };
 
   const handleLogout = () => {
@@ -106,7 +116,7 @@ export default function MyPageScreen() {
         showsVerticalScrollIndicator={false}
         refreshControl={
           <RefreshControl
-            refreshing={isRefetching}
+            refreshing={isManualRefreshing}
             onRefresh={onRefresh}
             tintColor={colors.primary}
           />
@@ -114,26 +124,26 @@ export default function MyPageScreen() {
       >
         <ProfileSection
           data={profileData}
-          isFetching={isRefetching}
-          isError={false}
+          isFetching={isProfileFetching}
+          isError={isProfileError}
           onRetry={refetchProfile}
         />
         <CreatedRunsSection
           data={createdRunsData}
-          isFetching={isRefetching}
-          isError={false}
+          isFetching={isCreatedRunsFetching}
+          isError={isCreatedRunsError}
           onRetry={refetchCreatedRuns}
         />
         <AppliedRunsSection
           data={appliedRunsData}
-          isFetching={isRefetching}
-          isError={false}
+          isFetching={isAppliedRunsFetching}
+          isError={isAppliedRunsError}
           onRetry={refetchAppliedRuns}
         />
         <RecentHistorySection
           data={historyRunsData}
-          isFetching={isRefetching}
-          isError={false}
+          isFetching={isHistoryRunsFetching}
+          isError={isHistoryRunsError}
           onRetry={refetchHistoryRuns}
         />
       </ScrollView>

--- a/src/components/mypage/Sections.tsx
+++ b/src/components/mypage/Sections.tsx
@@ -41,8 +41,6 @@ export const ProfileSection = ({
     );
   }
 
-  if (!profile) return null;
-
   if (isError) {
     return (
       <View style={[styles.sectionContainer, styles.centerBox]}>
@@ -53,22 +51,70 @@ export const ProfileSection = ({
       </View>
     );
   }
+
+  if (!profile) {
+    return (
+      <View style={styles.profileContainer}>
+        <View style={styles.profileHeader}>
+          {/* 회색 기본 아바타 */}
+          <View style={[styles.avatar, { backgroundColor: colors.gray300 }]}>
+            <Text style={styles.avatarText}>?</Text>
+          </View>
+          <View style={styles.profileInfo}>
+            <Text style={styles.name}>알 수 없는 사용자</Text>
+            <Text style={styles.demographics}>
+              사용자 정보를 확인할 수 없습니다
+            </Text>
+          </View>
+        </View>
+
+        {/* 하단 통계는 모두 0으로 기본값 처리 */}
+        <View style={styles.statsGrid}>
+          <StatBox label="주간 러닝" value="평균 0회" />
+          <StatBox label="평균 페이스" value="-" />
+          <StatBox label="총 러닝" value="0회" />
+          <StatBox label="누적 거리" value="0km" />
+        </View>
+      </View>
+    );
+  }
+
+  // 서버 데이터를 한글로 번역하기 위한 매핑
+  const genderMap: Record<string, string> = {
+    MALE: "남성",
+    FEMALE: "여성",
+  };
+
+  const ageGroupMap: Record<string, string> = {
+    "10S": "10대",
+    "20S": "20대",
+    "30S": "30대",
+    "40S": "40대",
+    "50S": "50대",
+  };
+
+  // 매핑 데이터에 없으면 원본 데이터를 그대로 보여줌
+  const displayGender = genderMap[profile.gender] || profile.gender;
+  const displayAge = ageGroupMap[profile.ageGroup] || profile.ageGroup;
+
+  // 이름이 없을 경우 에러 처리
+  const displayName = profile.name || "런닝메이트";
+  const avatarChar = displayName.charAt(0);
+
   return (
     <View style={styles.profileContainer}>
       <View style={styles.profileHeader}>
         <View style={styles.avatar}>
-          <Text style={styles.avatarText}>
-            {profile.name.charAt(profile.name.length - 1)}
-          </Text>
+          <Text style={styles.avatarText}>{avatarChar}</Text>
         </View>
         <View style={styles.profileInfo}>
-          <Text style={styles.name}>{profile.name}</Text>
+          <Text style={styles.name}>{displayName}</Text>
           <Text
             style={styles.demographics}
-          >{`${profile.ageGroup} · ${profile.gender}`}</Text>
+          >{`${displayAge} · ${displayGender}`}</Text>
           <Chip
             icon={<MannerIcon width={14} height={14} fill={colors.red} />}
-            label={`매너온도 ${profile.mannerTemp}°C`}
+            label={`매너온도 ${profile.mannerTemp ?? 36.5}°C`}
             color="red"
             size="small"
             style={styles.mannerChip}

--- a/src/hooks/mypage/useMyPageQueries.tsx
+++ b/src/hooks/mypage/useMyPageQueries.tsx
@@ -30,6 +30,16 @@ export function useMyPageQueries() {
         refetchCreatedRuns: results[1].refetch,
         refetchAppliedRuns: results[2].refetch,
         refetchHistoryRuns: results[3].refetch,
+
+        isProfileError: results[0].isError,
+        isCreatedRunsError: results[1].isError,
+        isAppliedRunsError: results[2].isError,
+        isHistoryRunsError: results[3].isError,
+
+        isProfileFetching: results[0].isFetching,
+        isCreatedRunsFetching: results[1].isFetching,
+        isAppliedRunsFetching: results[2].isFetching,
+        isHistoryRunsFetching: results[3].isFetching,
       };
     },
   });

--- a/src/types/api/mypage.ts
+++ b/src/types/api/mypage.ts
@@ -3,12 +3,14 @@ import type { GenderPolicy } from "../search/search";
 export type ApproveStatus = "PENDING" | "APPROVED" | "REJECTED";
 export type ResultStatus = "DONE" | "NOSHOW";
 export type RunningStatus = "OPEN" | "CLOSED" | "CANCELED" | "FINISHED";
+export type Gender = "MALE" | "FEMALE";
+export type AgeGroup = "10S" | "20S" | "30S" | "40S" | "50S";
 
 export interface UserProfile {
-  id: number;
+  userId: number;
   name: string;
-  ageGroup: string;
-  gender: string;
+  ageGroup: AgeGroup;
+  gender: Gender;
   weeklyRuns?: number;
   avgPaceMinPerKm?: string;
   mannerTemp: number;


### PR DESCRIPTION
## 📣 Related Issue
- close #28 

## 📝 Summary
- **백엔드 명세 동기화:** 백엔드 명세에 맞춰 마이페이지 데이터 타입과 인터페이스를 실제 환경과 동일하게 동기화했습니다.
- **UI 개선 및 런타임 방어:** 데이터 부재 시 컴포넌트가 화면에서 아예 사라지는 현상(`return null`)을 막기 위해 Empty State(기본 프로필) 뼈대 UI를 추가하고, 서버 영문 응답값(`MALE`, `30S`)을 한글로 렌더링하는 매핑 객체를 구현했습니다.
- **상태 관리 로직 분리:** 단일 섹션 재시도 시 최상단 `RefreshControl` 스피너가 함께 도는 오작동을 수정하기 위해, 4개 섹션의 개별 `isFetching` 상태와 수동 새로고침용 `isManualRefreshing` 로컬 상태를 완전히 분리했습니다.

## 🙏 Question & PR point
- **방어적 프로그래밍 및 UX 개선:** 프로필 통신 실패나 데이터 지연 시 화면이 하얗게 비어버리는 현상을 막기 위해 Empty State UI를 추가했습니다. '알 수 없는 사용자' 및 기본 아바타 처리가 UX 관점에서 자연스러운지 리뷰 부탁드립니다.
- **관심사의 분리 (상태 관리):** 기존 `useMyPageQueries`에서 글로벌 상태(`isRefetching`) 하나로 전체 로딩을 제어하던 구조를, 컴포넌트별 개별 `isFetching`과 당겨서 새로고침(`isManualRefreshing`) 상태로 격리했습니다. 이 상태 분리 아키텍처가 논리적으로 적절한지, 아니면 더 권장되는 패턴이 있을지 코멘트 남겨주시면 감사하겠습니다.