### PR TITLE
[FEAT] 참여자 관리 페이지 UI 구현 및 상태 연동

### DIFF
--- a/app/(main)/_layout.tsx
+++ b/app/(main)/_layout.tsx
@@ -99,6 +99,15 @@ export default function MainLayout() {
           headerLeft: () => <StackHeaderBack />,
         }}
       />
+      <Tabs.Screen
+        name="manage-participants"
+        options={{
+          href: null,
+          title: "참여자 관리",
+          tabBarStyle: { display: "none" },
+          headerLeft: () => <StackHeaderBack />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(main)/attendance.tsx
+++ b/app/(main)/attendance.tsx
@@ -1,0 +1,33 @@
+import { StyleSheet, Text, View } from "react-native";
+
+import { colors, fontSizes, fontWeights, spacing } from "@/src/constants";
+
+export default function AttendanceScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>출석 관리</Text>
+      <Text style={styles.hint}>
+        `/attendance`에 대응하는 화면입니다. (준비 중)
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: spacing.lg,
+    backgroundColor: colors.bgSecondary,
+    justifyContent: "center",
+  },
+  title: {
+    fontSize: fontSizes.xl,
+    fontWeight: fontWeights.bold,
+    color: colors.text,
+    marginBottom: spacing.sm,
+  },
+  hint: {
+    fontSize: fontSizes.sm,
+    color: colors.textSecondary,
+  },
+});

--- a/app/(main)/manage-participants.tsx
+++ b/app/(main)/manage-participants.tsx
@@ -1,45 +1,60 @@
-import { useQueries, useQueryClient } from "@tanstack/react-query";
-import { Tabs, useLocalSearchParams, useFocusEffect } from "expo-router";
-import { useCallback } from "react";
+import { useMutation, useQueries, useQueryClient } from "@tanstack/react-query";
+import {
+  Tabs,
+  useLocalSearchParams,
+  useFocusEffect,
+  router,
+} from "expo-router";
+import { useCallback, useState } from "react";
 import {
   ActivityIndicator,
   StyleSheet,
   View,
   Text,
   ScrollView,
+  Alert,
 } from "react-native";
 import {
   SafeAreaView,
   useSafeAreaInsets,
 } from "react-native-safe-area-context";
 
-import { getParticipantsByStatus } from "@/src/api/manageParticipants/manageParticipants.index";
+import {
+  closeSession,
+  getParticipantsByStatus,
+} from "@/src/api/manageParticipants/manageParticipants.index";
+import { participantKeys } from "@/src/api/manageParticipants/manageParticipants.keys";
 import { Button } from "@/src/components/common/button/Button";
 import { ApprovedParticipantCard } from "@/src/components/manageParticipants/ApprovedParticipantCard";
 import { ManageBottomBar } from "@/src/components/manageParticipants/ManageBottomBar";
 import { RequestedParticipantCard } from "@/src/components/manageParticipants/RequestedParticipantCard";
 import { EmptyState } from "@/src/components/mypage/EmptyState";
 import { colors, fontSizes, fontWeights, spacing } from "@/src/constants";
+import { RunningStatus } from "@/src/types/api/mypage";
 
 export default function ManageParticipantsScreen() {
   const insets = useSafeAreaInsets();
 
   const queryClient = useQueryClient();
 
-  const { id, title } = useLocalSearchParams<{
+  const { id, title, status } = useLocalSearchParams<{
     id: string;
     title: string;
+    status: RunningStatus;
   }>();
+
+  const [sessionStatus, setSessionStatus] = useState(status);
+
   const sessionId = Number(id);
 
   const { requestedList, approvedList, isError, isLoading } = useQueries({
     queries: [
       {
-        queryKey: ["participants", sessionId, "REQUESTED"],
+        queryKey: participantKeys.status(sessionId, "REQUESTED"),
         queryFn: () => getParticipantsByStatus(sessionId, "REQUESTED"),
       },
       {
-        queryKey: ["participants", sessionId, "APPROVED"],
+        queryKey: participantKeys.status(sessionId, "APPROVED"),
         queryFn: () => getParticipantsByStatus(sessionId, "APPROVED"),
       },
     ],
@@ -55,27 +70,78 @@ export default function ManageParticipantsScreen() {
     },
   });
 
+  const { mutate: closeMutate, isPending: isCloseSession } = useMutation({
+    mutationFn: () => closeSession(sessionId),
+
+    onSuccess: () => {
+      Alert.alert("마감 완료", "모집이 성공적으로 마감되었습니다.", [
+        {
+          text: "확인",
+          onPress: () => {
+            setSessionStatus("CLOSED");
+            queryClient.invalidateQueries({
+              queryKey: participantKeys.all(sessionId),
+            });
+          },
+        },
+      ]);
+    },
+
+    onError: () => {
+      Alert.alert("모집 마감에 실패하였습니다", "잠시후 다시 시도해주세요", [
+        {
+          text: "확인",
+          onPress: () => {
+            queryClient.invalidateQueries({
+              queryKey: participantKeys.all(sessionId),
+            });
+          },
+        },
+      ]);
+    },
+  });
+
   useFocusEffect(
     useCallback(() => {
       // 화면에 다시 들어올 때마다 해당 세션의 데이터를 상한 데이터로 취급하여 즉시 백그라운드 재요청
-      queryClient.invalidateQueries({ queryKey: ["participants", sessionId] });
+      queryClient.invalidateQueries({
+        queryKey: participantKeys.all(sessionId),
+      });
     }, [sessionId, queryClient]),
   );
 
   const onRefresh = async () => {
-    queryClient.invalidateQueries({ queryKey: ["participants", sessionId] });
+    queryClient.invalidateQueries({ queryKey: participantKeys.all(sessionId) });
   };
 
   const onClose = () => {
-    // TODO: [API 연동] 세션의 모집 상태를 모집 마감으로 변경하는 API 호출
-    // TODO: [상태/UI] 성공 시 알림 표시
-    // eslint-disable-next-line no-console
-    console.log("모집 마감", sessionId);
+    Alert.alert(
+      "모집 마감",
+      "모집을 마감하시겠습니까?\n마감 후에는 새로운 신청을 받을 수 없습니다.",
+      [
+        {
+          text: "취소",
+          style: "cancel",
+        },
+        {
+          text: "확인",
+          style: "destructive",
+          onPress: () => closeMutate(),
+        },
+      ],
+      { cancelable: true },
+    );
   };
   const onCheckStart = () => {
-    // TODO: [화면 이동] 출석 체크를 진행하는 스크린으로 이동 (sessionId 파라미터 전달)
-    // eslint-disable-next-line no-console
-    console.log("출석 체크 시작", sessionId);
+    if (sessionStatus === "OPEN") {
+      Alert.alert("안내", "모집 마감을 한 뒤 출석 체크를 진행 해주세요");
+      return;
+    }
+
+    router.push({
+      pathname: "/attendance",
+      params: { id: sessionId },
+    });
   };
 
   if (isLoading) {
@@ -131,18 +197,7 @@ export default function ManageParticipantsScreen() {
             <RequestedParticipantCard
               key={participant.id}
               participant={participant}
-              onAccept={(id) => {
-                // TODO: [API 연동] 해당 유저의 참여 상태를 수락으로 변경하는 API 호출
-                // TODO: [상태 업데이트] API 성공 후 목록 새로고침
-                // eslint-disable-next-line no-console
-                console.log("수락", id);
-              }}
-              onReject={(id) => {
-                // TODO: [API 연동] 해당 유저의 참여 상태를 거절로 변경하는 API 호출
-                // TODO: [상태 업데이트] API 성공 후 목록 새로고침
-                // eslint-disable-next-line no-console
-                console.log("거절", id);
-              }}
+              sessionId={sessionId}
             />
           ))
         )}
@@ -169,8 +224,10 @@ export default function ManageParticipantsScreen() {
       <View style={[styles.fixedBottomBtn, { paddingBottom: insets.bottom }]}>
         <ManageBottomBar
           sessionId={sessionId}
+          isClosed={sessionStatus}
           onClose={onClose}
           onCheckStart={onCheckStart}
+          isCloseSession={isCloseSession}
         />
       </View>
     </View>

--- a/app/(main)/manage-participants.tsx
+++ b/app/(main)/manage-participants.tsx
@@ -1,0 +1,241 @@
+import { useQueries, useQueryClient } from "@tanstack/react-query";
+import { Tabs, useLocalSearchParams, useFocusEffect } from "expo-router";
+import { useCallback } from "react";
+import {
+  ActivityIndicator,
+  StyleSheet,
+  View,
+  Text,
+  ScrollView,
+} from "react-native";
+import {
+  SafeAreaView,
+  useSafeAreaInsets,
+} from "react-native-safe-area-context";
+
+import { getParticipantsByStatus } from "@/src/api/manageParticipants/manageParticipants.index";
+import { Button } from "@/src/components/common/button/Button";
+import { ApprovedParticipantCard } from "@/src/components/manageParticipants/ApprovedParticipantCard";
+import { ManageBottomBar } from "@/src/components/manageParticipants/ManageBottomBar";
+import { RequestedParticipantCard } from "@/src/components/manageParticipants/RequestedParticipantCard";
+import { EmptyState } from "@/src/components/mypage/EmptyState";
+import { colors, fontSizes, fontWeights, spacing } from "@/src/constants";
+
+export default function ManageParticipantsScreen() {
+  const insets = useSafeAreaInsets();
+
+  const queryClient = useQueryClient();
+
+  const { id, title } = useLocalSearchParams<{
+    id: string;
+    title: string;
+  }>();
+  const sessionId = Number(id);
+
+  const { requestedList, approvedList, isError, isLoading } = useQueries({
+    queries: [
+      {
+        queryKey: ["participants", sessionId, "REQUESTED"],
+        queryFn: () => getParticipantsByStatus(sessionId, "REQUESTED"),
+      },
+      {
+        queryKey: ["participants", sessionId, "APPROVED"],
+        queryFn: () => getParticipantsByStatus(sessionId, "APPROVED"),
+      },
+    ],
+
+    combine: (results) => {
+      return {
+        requestedList: results[0].data ?? [],
+        approvedList: results[1].data ?? [],
+
+        isLoading: results[0].isLoading || results[1].isLoading,
+        isError: results[0].isError || results[1].isError,
+      };
+    },
+  });
+
+  useFocusEffect(
+    useCallback(() => {
+      // 화면에 다시 들어올 때마다 해당 세션의 데이터를 상한 데이터로 취급하여 즉시 백그라운드 재요청
+      queryClient.invalidateQueries({ queryKey: ["participants", sessionId] });
+    }, [sessionId, queryClient]),
+  );
+
+  const onRefresh = async () => {
+    queryClient.invalidateQueries({ queryKey: ["participants", sessionId] });
+  };
+
+  const onClose = () => {
+    // TODO: [API 연동] 세션의 모집 상태를 모집 마감으로 변경하는 API 호출
+    // TODO: [상태/UI] 성공 시 알림 표시
+    // eslint-disable-next-line no-console
+    console.log("모집 마감", sessionId);
+  };
+  const onCheckStart = () => {
+    // TODO: [화면 이동] 출석 체크를 진행하는 스크린으로 이동 (sessionId 파라미터 전달)
+    // eslint-disable-next-line no-console
+    console.log("출석 체크 시작", sessionId);
+  };
+
+  if (isLoading) {
+    return (
+      <SafeAreaView
+        style={[
+          styles.container,
+          { justifyContent: "center", alignItems: "center" },
+        ]}
+      >
+        <ActivityIndicator size="large" color={colors.primary} />
+        <Text style={styles.loadingText}>참여자 정보를 불러오는 중입니다</Text>
+      </SafeAreaView>
+    );
+  }
+
+  if (isError) {
+    return (
+      <View style={styles.centerBox}>
+        <Text style={styles.errorText}>데이터를 불러오지 못했습니다.</Text>
+        <Button variant="outline" size="sm" onPress={onRefresh}>
+          다시 시도
+        </Button>
+      </View>
+    );
+  }
+  return (
+    <View style={styles.container}>
+      <Tabs.Screen
+        options={{
+          headerTitle: () => (
+            <View style={styles.headerTitleContainer}>
+              <Text style={styles.headerMainText}>참여자 관리</Text>
+              <Text style={styles.headerSubText}>{title}</Text>
+            </View>
+          ),
+        }}
+      />
+      <ScrollView
+        style={styles.scrollContainer}
+        contentContainerStyle={styles.scrollContent}
+      >
+        <Text style={styles.approvedText}>
+          신청 대기 ({requestedList.length}) 명
+        </Text>
+
+        {requestedList.length === 0 ? (
+          <View style={styles.cardContainer}>
+            <EmptyState text="아직 대기 중인 신청자가 없습니다." />
+          </View>
+        ) : (
+          requestedList.map((participant) => (
+            <RequestedParticipantCard
+              key={participant.id}
+              participant={participant}
+              onAccept={(id) => {
+                // TODO: [API 연동] 해당 유저의 참여 상태를 수락으로 변경하는 API 호출
+                // TODO: [상태 업데이트] API 성공 후 목록 새로고침
+                // eslint-disable-next-line no-console
+                console.log("수락", id);
+              }}
+              onReject={(id) => {
+                // TODO: [API 연동] 해당 유저의 참여 상태를 거절로 변경하는 API 호출
+                // TODO: [상태 업데이트] API 성공 후 목록 새로고침
+                // eslint-disable-next-line no-console
+                console.log("거절", id);
+              }}
+            />
+          ))
+        )}
+
+        <View>
+          <Text style={styles.approvedText}>
+            확정 멤버 ({approvedList.length}) 명
+          </Text>
+          <View style={styles.cardContainer}>
+            {approvedList.length === 0 ? (
+              <EmptyState text="확정 멤버가 없습니다." />
+            ) : (
+              approvedList.map((participant, index) => (
+                <ApprovedParticipantCard
+                  key={participant.id}
+                  participant={participant}
+                  isLast={index === approvedList.length - 1} // 마지막 요소인지 판별해서 넘김
+                />
+              ))
+            )}
+          </View>
+        </View>
+      </ScrollView>
+      <View style={[styles.fixedBottomBtn, { paddingBottom: insets.bottom }]}>
+        <ManageBottomBar
+          sessionId={sessionId}
+          onClose={onClose}
+          onCheckStart={onCheckStart}
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: colors.bgSecondary },
+  scrollContainer: { flex: 1 },
+  loadingText: {
+    marginTop: spacing.md,
+    color: colors.textSecondary,
+  },
+  centerBox: {
+    alignItems: "center",
+  },
+  errorText: {
+    color: colors.error,
+  },
+  approvedText: {
+    color: colors.black,
+    fontSize: fontSizes.md,
+    fontWeight: fontWeights.semibold,
+    marginLeft: 16,
+    marginBottom: 16,
+    marginTop: 16,
+  },
+  cardContainer: {
+    backgroundColor: colors.bg,
+    borderRadius: 16,
+    paddingHorizontal: 20,
+    borderWidth: 1,
+    borderColor: colors.gray200,
+    shadowColor: colors.black,
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.05,
+    shadowRadius: 8,
+    elevation: 2,
+    marginHorizontal: 16,
+  },
+  fixedBottomBtn: {
+    backgroundColor: colors.bg,
+    justifyContent: "center",
+    borderTopWidth: 1,
+    borderTopColor: colors.gray200,
+    paddingTop: 12,
+    paddingHorizontal: 12,
+  },
+
+  scrollContent: {
+    paddingBottom: 40,
+    paddingTop: 20,
+  },
+  headerTitleContainer: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  headerMainText: {
+    fontSize: fontSizes.lg,
+    fontWeight: fontWeights.bold,
+    color: colors.gray600,
+  },
+  headerSubText: {
+    fontSize: fontSizes.sm,
+    color: colors.textSecondary,
+    marginTop: 2,
+  },
+});

--- a/src/api/manageParticipants/manageParticipants.index.ts
+++ b/src/api/manageParticipants/manageParticipants.index.ts
@@ -1,0 +1,8 @@
+import { getParticipantsByStatus as realGetParticipantsByStatus } from "./manageParticipants";
+import { getParticipantsByStatus as mockGetParticipantsByStatus } from "./manageParticipants.mock";
+
+const isMock = process.env.EXPO_PUBLIC_USE_MOCK === "true";
+
+export const getParticipantsByStatus = isMock
+  ? mockGetParticipantsByStatus
+  : realGetParticipantsByStatus;

--- a/src/api/manageParticipants/manageParticipants.index.ts
+++ b/src/api/manageParticipants/manageParticipants.index.ts
@@ -1,8 +1,28 @@
-import { getParticipantsByStatus as realGetParticipantsByStatus } from "./manageParticipants";
-import { getParticipantsByStatus as mockGetParticipantsByStatus } from "./manageParticipants.mock";
+import {
+  getParticipantsByStatus as realGetParticipantsByStatus,
+  acceptParticipant as realAcceptParticipant,
+  rejectParticipant as realRejectParticipantal,
+  closeSession as realCloseSession,
+} from "./manageParticipants";
+import {
+  getParticipantsByStatus as mockGetParticipantsByStatus,
+  acceptParticipant as mockAcceptParticipant,
+  rejectParticipant as mockRejectParticipant,
+  closeSession as mockCloseSession,
+} from "./manageParticipants.mock";
 
 const isMock = process.env.EXPO_PUBLIC_USE_MOCK === "true";
 
 export const getParticipantsByStatus = isMock
   ? mockGetParticipantsByStatus
   : realGetParticipantsByStatus;
+
+export const acceptParticipant = isMock
+  ? mockAcceptParticipant
+  : realAcceptParticipant;
+
+export const rejectParticipant = isMock
+  ? mockRejectParticipant
+  : realRejectParticipantal;
+
+export const closeSession = isMock ? mockCloseSession : realCloseSession;

--- a/src/api/manageParticipants/manageParticipants.keys.ts
+++ b/src/api/manageParticipants/manageParticipants.keys.ts
@@ -1,0 +1,10 @@
+import { RequestStatus } from "@/src/types/api/manageParticipants";
+
+export const participantKeys = {
+  // 특정 세션의 모든 참여자 데이터를 통째로 새로고침 할 때 사용
+  all: (sessionId: number) => ["participants", sessionId] as const,
+
+  // REQUESTED, APPROVED 등 상태별로 따로 조회할 때 사용
+  status: (sessionId: number, status: RequestStatus) =>
+    [...participantKeys.all(sessionId), status] as const,
+};

--- a/src/api/manageParticipants/manageParticipants.mock.ts
+++ b/src/api/manageParticipants/manageParticipants.mock.ts
@@ -1,0 +1,76 @@
+import { JoinRequest } from "@/src/types/api/manageParticipants";
+
+export const mockRequestedMembers: JoinRequest[] = [
+  {
+    id: 101,
+    userId: 1,
+    userName: "박서준",
+    userGender: "MALE",
+    status: "REQUESTED",
+    attendanceStatus: "DEFAULT",
+    messageToHost: "페이스가 저랑 딱 맞네요! 열심히 뛰겠습니다.",
+    requestedAt: "2026-06-29T08:30:00.000Z",
+  },
+  {
+    id: 102,
+    userId: 2,
+    userName: "이민지",
+    userGender: "FEMALE",
+    status: "REQUESTED",
+    attendanceStatus: "DEFAULT",
+    messageToHost: "여의도에서 자주 뛰는데 같이 달리고 싶어요!",
+    requestedAt: "2026-06-29T09:15:00.000Z",
+  },
+];
+
+export const mockApprovedMembers: JoinRequest[] = [
+  {
+    id: 103,
+    userId: 3,
+    userName: "러너김",
+    userGender: "MALE",
+    status: "APPROVED",
+    attendanceStatus: "DEFAULT",
+    messageToHost: "잘 부탁드립니다! 시간 맞춰서 가겠습니다.",
+    requestedAt: "2026-06-28T14:20:00.000Z",
+  },
+  {
+    id: 104,
+    userId: 4,
+    userName: "정수아",
+    userGender: "FEMALE",
+    status: "APPROVED",
+    attendanceStatus: "DEFAULT",
+    messageToHost: "오랜만에 러닝이네요, 기대됩니다.",
+    requestedAt: "2026-06-28T15:45:00.000Z",
+  },
+  {
+    id: 105,
+    userId: 5,
+    userName: "최다은",
+    userGender: "FEMALE",
+    status: "APPROVED",
+    attendanceStatus: "DEFAULT",
+    messageToHost: "항상 뛰던 코스라 바로 신청합니다.",
+    requestedAt: "2026-06-28T18:10:00.000Z",
+  },
+];
+
+export const getParticipantsByStatus = async (
+  _sessionId: number,
+  status: string,
+): Promise<JoinRequest[]> => {
+  if (status === "REQUESTED") {
+    return new Promise((resolve) =>
+      setTimeout(() => resolve(mockRequestedMembers), 1200),
+    );
+  }
+
+  if (status === "APPROVED") {
+    return new Promise((resolve) =>
+      setTimeout(() => resolve(mockApprovedMembers), 1200),
+    );
+  }
+
+  return new Promise((resolve) => setTimeout(() => resolve([]), 1200));
+};

--- a/src/api/manageParticipants/manageParticipants.mock.ts
+++ b/src/api/manageParticipants/manageParticipants.mock.ts
@@ -1,6 +1,6 @@
 import { JoinRequest } from "@/src/types/api/manageParticipants";
 
-export const mockRequestedMembers: JoinRequest[] = [
+let mockRequestedMembers: JoinRequest[] = [
   {
     id: 101,
     userId: 1,
@@ -23,7 +23,7 @@ export const mockRequestedMembers: JoinRequest[] = [
   },
 ];
 
-export const mockApprovedMembers: JoinRequest[] = [
+const mockApprovedMembers: JoinRequest[] = [
   {
     id: 103,
     userId: 3,
@@ -62,36 +62,48 @@ export const getParticipantsByStatus = async (
 ): Promise<JoinRequest[]> => {
   if (status === "REQUESTED") {
     return new Promise((resolve) =>
-      setTimeout(() => resolve(mockRequestedMembers), 1200),
+      setTimeout(() => resolve(mockRequestedMembers), 800),
     );
   }
 
   if (status === "APPROVED") {
     return new Promise((resolve) =>
-      setTimeout(() => resolve(mockApprovedMembers), 1200),
+      setTimeout(() => resolve(mockApprovedMembers), 800),
     );
   }
 
-  return new Promise((resolve) => setTimeout(() => resolve([]), 1200));
+  return new Promise((resolve) => setTimeout(() => resolve([]), 800));
 };
 
 export const acceptParticipant = async (
   _sessionId: number,
-  _participantId: number,
+  participantId: number,
 ): Promise<void> => {
   await new Promise((resolve) => setTimeout(resolve, 500));
-  return;
+
+  const targetIndex = mockRequestedMembers.findIndex(
+    (m) => m.id === participantId,
+  );
+  if (targetIndex !== -1) {
+    const [targetMember] = mockRequestedMembers.splice(targetIndex, 1);
+    targetMember.status = "APPROVED";
+    mockApprovedMembers.push(targetMember);
+  }
 };
 
 export const rejectParticipant = async (
   _sessionId: number,
-  _participantId: number,
+  participantId: number,
 ): Promise<void> => {
   await new Promise((resolve) => setTimeout(resolve, 500));
-  return;
+
+  mockRequestedMembers = mockRequestedMembers.filter(
+    (m) => m.id !== participantId,
+  );
 };
 
 export const closeSession = async (_sessionId: number): Promise<void> => {
   await new Promise((resolve) => setTimeout(resolve, 500));
-  return;
+
+  mockRequestedMembers = [];
 };

--- a/src/api/manageParticipants/manageParticipants.mock.ts
+++ b/src/api/manageParticipants/manageParticipants.mock.ts
@@ -74,3 +74,24 @@ export const getParticipantsByStatus = async (
 
   return new Promise((resolve) => setTimeout(() => resolve([]), 1200));
 };
+
+export const acceptParticipant = async (
+  _sessionId: number,
+  _participantId: number,
+): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  return;
+};
+
+export const rejectParticipant = async (
+  _sessionId: number,
+  _participantId: number,
+): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  return;
+};
+
+export const closeSession = async (_sessionId: number): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  return;
+};

--- a/src/api/manageParticipants/manageParticipants.ts
+++ b/src/api/manageParticipants/manageParticipants.ts
@@ -1,0 +1,13 @@
+import { axiosInstance } from "../axiosInstance";
+
+import { JoinRequest } from "@/src/types/api/manageParticipants";
+
+export const getParticipantsByStatus = async (
+  sessionId: number,
+  status: string,
+): Promise<JoinRequest[]> => {
+  const response = await axiosInstance.get(
+    `/sessions/${sessionId}/join-requests?status=${status}`,
+  );
+  return response.data;
+};

--- a/src/api/manageParticipants/manageParticipants.ts
+++ b/src/api/manageParticipants/manageParticipants.ts
@@ -11,3 +11,25 @@ export const getParticipantsByStatus = async (
   );
   return response.data;
 };
+
+export const acceptParticipant = async (
+  sessionId: number,
+  participationId: number,
+): Promise<void> => {
+  await axiosInstance.post(
+    `sessions/${sessionId}/join-requests/${participationId}/approve`,
+  );
+};
+
+export const rejectParticipant = async (
+  sessionId: number,
+  participationId: number,
+): Promise<void> => {
+  await axiosInstance.post(
+    `sessions/${sessionId}/join-requests/${participationId}/reject`,
+  );
+};
+
+export const closeSession = async (sessionId: number): Promise<void> => {
+  await axiosInstance.post(`sessions/${sessionId}/close`);
+};

--- a/src/api/my-page/myPageApi.mock.ts
+++ b/src/api/my-page/myPageApi.mock.ts
@@ -11,10 +11,10 @@ import {
 
 // 마이페이지 프로필 데이터
 export const MOCK_PROFILE: UserProfile = {
-  id: 1,
+  userId: 1,
   name: "러너김",
-  ageGroup: "30대",
-  gender: "남성",
+  ageGroup: "20S",
+  gender: "MALE",
   mannerTemp: 36.5,
   weeklyRuns: 3,
   avgPaceMinPerKm: "5:45 min/km",

--- a/src/assets/icon/manage-Participants/accept.svg
+++ b/src/assets/icon/manage-Participants/accept.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M16.6621 4.99854L7.49767 14.1629L3.33203 9.99731" stroke="white" stroke-width="1.66626" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/icon/manage-Participants/reject.svg
+++ b/src/assets/icon/manage-Participants/reject.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14.9966 4.99854L4.99902 14.9961" stroke="#364153" stroke-width="1.66626" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.99902 4.99854L14.9966 14.9961" stroke="#364153" stroke-width="1.66626" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/manageParticipants/ApprovedParticipantCard.tsx
+++ b/src/components/manageParticipants/ApprovedParticipantCard.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+
+import { ParticipantProfile } from "./ParticipantProfile";
+
+import { colors, spacing } from "@/src/constants";
+import { JoinRequest } from "@/src/types/api/manageParticipants";
+
+interface ApprovedParticipantCardProps {
+  participant: JoinRequest;
+  isLast: boolean;
+}
+
+export const ApprovedParticipantCard = ({
+  participant,
+  isLast,
+}: ApprovedParticipantCardProps) => {
+  return (
+    <>
+      <View style={styles.rowContainer}>
+        <ParticipantProfile participant={participant} />
+      </View>
+
+      {/* 마지막 요소가 아닐 때만 하단 구분선 렌더링 */}
+      {!isLast && <View style={styles.divider} />}
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  rowContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: spacing.md,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: colors.borderLight,
+  },
+});

--- a/src/components/manageParticipants/ManageBottomBar.tsx
+++ b/src/components/manageParticipants/ManageBottomBar.tsx
@@ -3,29 +3,37 @@ import { StyleSheet, View } from "react-native";
 import { Button } from "../common/button/Button";
 
 import { colors, fontSizes, fontWeights, spacing } from "@/src/constants";
+import { RunningStatus } from "@/src/types/api/mypage";
 
 interface ManageBottomBarProps {
   sessionId: number;
+  isClosed: RunningStatus;
   onClose: (id: number) => void;
   onCheckStart: (id: number) => void;
+  isCloseSession: boolean;
 }
 
 export function ManageBottomBar({
   sessionId,
+  isClosed,
   onClose,
   onCheckStart,
+  isCloseSession,
 }: ManageBottomBarProps) {
   return (
     <View style={styles.buttonRow}>
-      <Button
-        variant="neutral"
-        flex={1}
-        onPress={() => onClose(sessionId)}
-        wrapperStyle={styles.rejectButton}
-        textStyle={styles.rejectButtonText}
-      >
-        모집 마감
-      </Button>
+      {isClosed === "OPEN" && (
+        <Button
+          variant="neutral"
+          flex={1}
+          onPress={() => onClose(sessionId)}
+          wrapperStyle={styles.rejectButton}
+          textStyle={styles.rejectButtonText}
+          disabled={isCloseSession}
+        >
+          {isCloseSession ? "마감 중.." : "모집 마감"}
+        </Button>
+      )}
 
       <Button
         variant="primary"

--- a/src/components/manageParticipants/ManageBottomBar.tsx
+++ b/src/components/manageParticipants/ManageBottomBar.tsx
@@ -1,0 +1,66 @@
+import { StyleSheet, View } from "react-native";
+
+import { Button } from "../common/button/Button";
+
+import { colors, fontSizes, fontWeights, spacing } from "@/src/constants";
+
+interface ManageBottomBarProps {
+  sessionId: number;
+  onClose: (id: number) => void;
+  onCheckStart: (id: number) => void;
+}
+
+export function ManageBottomBar({
+  sessionId,
+  onClose,
+  onCheckStart,
+}: ManageBottomBarProps) {
+  return (
+    <View style={styles.buttonRow}>
+      <Button
+        variant="neutral"
+        flex={1}
+        onPress={() => onClose(sessionId)}
+        wrapperStyle={styles.rejectButton}
+        textStyle={styles.rejectButtonText}
+      >
+        모집 마감
+      </Button>
+
+      <Button
+        variant="primary"
+        flex={1}
+        onPress={() => onCheckStart(sessionId)}
+        wrapperStyle={styles.acceptButton}
+        textStyle={styles.acceptButtonText}
+      >
+        출석 체크 시작
+      </Button>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  buttonRow: {
+    flexDirection: "row",
+    gap: spacing.md,
+  },
+  rejectButton: {
+    backgroundColor: colors.gray100,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  rejectButtonText: {
+    color: colors.text,
+    fontSize: fontSizes.base,
+    fontWeight: fontWeights.semibold,
+  },
+  acceptButton: {
+    backgroundColor: colors.main,
+  },
+  acceptButtonText: {
+    color: colors.white,
+    fontSize: fontSizes.base,
+    fontWeight: fontWeights.semibold,
+  },
+});

--- a/src/components/manageParticipants/ParticipantProfile.tsx
+++ b/src/components/manageParticipants/ParticipantProfile.tsx
@@ -1,0 +1,72 @@
+import { View, Text, StyleSheet } from "react-native";
+
+import Chip from "../common/chip";
+
+import { colors, fontSizes, fontWeights, spacing } from "@/src/constants";
+import { GENDER_MAP, getGenderColor } from "@/src/constants/mappings";
+import { JoinRequest } from "@/src/types/api/manageParticipants";
+
+interface ParticipantProfileProps {
+  participant: JoinRequest;
+}
+
+export const ParticipantProfile = ({
+  participant,
+}: ParticipantProfileProps) => {
+  const displayGender =
+    GENDER_MAP[participant.userGender] || participant.userGender;
+
+  return (
+    <View style={styles.profileSection}>
+      {/* 좌측: 아바타 */}
+      <View
+        style={[
+          styles.avatar,
+          { backgroundColor: getGenderColor(participant.userGender) },
+        ]}
+      >
+        <Text style={styles.avatarText}>{participant.userName.charAt(0)}</Text>
+      </View>
+
+      {/* 우측: 이름 및 성별 뱃지 */}
+      <View style={styles.infoContainer}>
+        <Text style={styles.nameText}>{participant.userName}</Text>
+        <Chip
+          label={displayGender}
+          size="small"
+          color={participant.userGender === "MALE" ? "primary" : "red"}
+        />
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  profileSection: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.md,
+  },
+  avatar: {
+    width: spacing.xxxl,
+    height: spacing.xxxl,
+    borderRadius: 24,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  avatarText: {
+    color: colors.white,
+    fontSize: fontSizes.md,
+    fontWeight: fontWeights.bold,
+  },
+  infoContainer: {
+    flexDirection: "column",
+    justifyContent: "center",
+    gap: spacing.xs,
+  },
+  nameText: {
+    fontSize: fontSizes.md,
+    fontWeight: fontWeights.bold,
+    color: colors.text,
+  },
+});

--- a/src/components/manageParticipants/RequestedParticipantCard.tsx
+++ b/src/components/manageParticipants/RequestedParticipantCard.tsx
@@ -1,0 +1,129 @@
+import { View, Text, StyleSheet } from "react-native";
+
+import { Button } from "../common/button/Button";
+
+import { ParticipantProfile } from "./ParticipantProfile";
+
+import AcceptSvg from "@/src/assets/icon/manage-Participants/accept.svg";
+import RejectSvg from "@/src/assets/icon/manage-Participants/reject.svg";
+import {
+  borderRadius,
+  colors,
+  fontSizes,
+  fontWeights,
+  spacing,
+} from "@/src/constants";
+import { JoinRequest } from "@/src/types/api/manageParticipants";
+
+interface RequestedParticipantCardProps {
+  participant: JoinRequest;
+  onAccept: (id: number) => void;
+  onReject: (id: number) => void;
+}
+
+export const RequestedParticipantCard = ({
+  participant,
+  onAccept,
+  onReject,
+}: RequestedParticipantCardProps) => {
+  return (
+    <View style={styles.cardContainer}>
+      {/* Header */}
+      <View style={styles.headerRow}>
+        <ParticipantProfile participant={participant} />
+      </View>
+      {/* Message */}
+      {!!participant.messageToHost && (
+        <View style={styles.messageBox}>
+          <Text style={styles.messageText}>{participant.messageToHost}</Text>
+        </View>
+      )}
+
+      {/* 거절 / 수락 버튼 */}
+      <View style={styles.buttonRow}>
+        <Button
+          variant="outline"
+          flex={1}
+          rounded
+          startIcon={<RejectSvg width={18} height={18} />}
+          onPress={() => onReject(participant.id)}
+          wrapperStyle={styles.rejectButton}
+          textStyle={styles.rejectButtonText}
+        >
+          거절
+        </Button>
+
+        <Button
+          variant="primary"
+          flex={1}
+          rounded
+          startIcon={<AcceptSvg width={18} height={18} />}
+          onPress={() => onAccept(participant.id)}
+          wrapperStyle={styles.acceptButton}
+          textStyle={styles.acceptButtonText}
+        >
+          수락
+        </Button>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  cardContainer: {
+    backgroundColor: colors.bg,
+    borderRadius: borderRadius.xl,
+    padding: spacing.lg,
+    marginHorizontal: spacing.base,
+    marginVertical: spacing.sm,
+    shadowColor: colors.black,
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.05,
+    shadowRadius: borderRadius.md,
+    elevation: 2,
+    borderWidth: 1,
+    borderColor: colors.gray200,
+  },
+
+  headerRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: spacing.base,
+  },
+
+  messageBox: {
+    backgroundColor: colors.bgSecondary,
+    padding: spacing.base,
+    borderRadius: borderRadius.lg,
+    marginBottom: spacing.lg,
+  },
+  messageText: {
+    fontSize: fontSizes.sm,
+    color: colors.text,
+    lineHeight: 20,
+  },
+
+  buttonRow: {
+    flexDirection: "row",
+    gap: spacing.md,
+  },
+  rejectButton: {
+    backgroundColor: colors.bg,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  rejectButtonText: {
+    color: colors.textSecondary,
+    fontSize: fontSizes.base,
+    fontWeight: fontWeights.semibold,
+  },
+  acceptButton: {
+    backgroundColor: colors.main,
+  },
+  acceptButtonText: {
+    color: colors.bg,
+    fontSize: fontSizes.base,
+    fontWeight: fontWeights.semibold,
+  },
+});

--- a/src/components/manageParticipants/RequestedParticipantCard.tsx
+++ b/src/components/manageParticipants/RequestedParticipantCard.tsx
@@ -1,9 +1,15 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { View, Text, StyleSheet } from "react-native";
 
 import { Button } from "../common/button/Button";
 
 import { ParticipantProfile } from "./ParticipantProfile";
 
+import {
+  acceptParticipant,
+  rejectParticipant,
+} from "@/src/api/manageParticipants/manageParticipants.index";
+import { participantKeys } from "@/src/api/manageParticipants/manageParticipants.keys";
 import AcceptSvg from "@/src/assets/icon/manage-Participants/accept.svg";
 import RejectSvg from "@/src/assets/icon/manage-Participants/reject.svg";
 import {
@@ -17,15 +23,46 @@ import { JoinRequest } from "@/src/types/api/manageParticipants";
 
 interface RequestedParticipantCardProps {
   participant: JoinRequest;
-  onAccept: (id: number) => void;
-  onReject: (id: number) => void;
+  sessionId: number;
 }
 
 export const RequestedParticipantCard = ({
   participant,
-  onAccept,
-  onReject,
+  sessionId,
 }: RequestedParticipantCardProps) => {
+  const queryClient = useQueryClient();
+
+  const { mutate: acceptMutate, isPending: isAccepting } = useMutation({
+    mutationFn: (participantId: number) =>
+      acceptParticipant(sessionId, participantId),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: participantKeys.all(sessionId),
+      });
+    },
+
+    onError: (err) => {
+      console.error("수락 실패", err);
+    },
+  });
+
+  const { mutate: rejectMutate, isPending: isRejecting } = useMutation({
+    mutationFn: (participantId: number) =>
+      rejectParticipant(sessionId, participantId),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: participantKeys.all(sessionId),
+      });
+    },
+
+    onError: (err) => {
+      console.error("거절 실패", err);
+    },
+  });
+
+  const isSubmitting = isAccepting || isRejecting;
   return (
     <View style={styles.cardContainer}>
       {/* Header */}
@@ -46,7 +83,8 @@ export const RequestedParticipantCard = ({
           flex={1}
           rounded
           startIcon={<RejectSvg width={18} height={18} />}
-          onPress={() => onReject(participant.id)}
+          onPress={() => rejectMutate(participant.id)}
+          disabled={isSubmitting}
           wrapperStyle={styles.rejectButton}
           textStyle={styles.rejectButtonText}
         >
@@ -58,7 +96,8 @@ export const RequestedParticipantCard = ({
           flex={1}
           rounded
           startIcon={<AcceptSvg width={18} height={18} />}
-          onPress={() => onAccept(participant.id)}
+          onPress={() => acceptMutate(participant.id)}
+          disabled={isSubmitting}
           wrapperStyle={styles.acceptButton}
           textStyle={styles.acceptButtonText}
         >

--- a/src/components/mypage/Sections.tsx
+++ b/src/components/mypage/Sections.tsx
@@ -12,8 +12,8 @@ import CheckIcon from "@/src/assets/icon/my-page/check.svg";
 import MannerIcon from "@/src/assets/icon/my-page/manner.svg";
 import Chip from "@/src/components/common/chip";
 import { colors } from "@/src/constants/index";
-import type { UserProfile } from "@/src/types/api/mypage";
-import { CreatedRunning } from "@/src/types/api/mypage";
+import { AGEGROUPMAP, GENDER_MAP } from "@/src/constants/mappings";
+import { CreatedRunning, UserProfile } from "@/src/types/api/mypage";
 import {
   AppliedRunningsResponse,
   RecentRunningsResponse,
@@ -80,23 +80,9 @@ export const ProfileSection = ({
     );
   }
 
-  // 서버 데이터를 한글로 번역하기 위한 매핑
-  const genderMap: Record<string, string> = {
-    MALE: "남성",
-    FEMALE: "여성",
-  };
-
-  const ageGroupMap: Record<string, string> = {
-    "10S": "10대",
-    "20S": "20대",
-    "30S": "30대",
-    "40S": "40대",
-    "50S": "50대",
-  };
-
   // 매핑 데이터에 없으면 원본 데이터를 그대로 보여줌
-  const displayGender = genderMap[profile.gender] || profile.gender;
-  const displayAge = ageGroupMap[profile.ageGroup] || profile.ageGroup;
+  const displayGender = GENDER_MAP[profile.gender] || profile.gender;
+  const displayAge = AGEGROUPMAP[profile.ageGroup] || profile.ageGroup;
 
   // 이름이 없을 경우 에러 처리
   const displayName = profile.name || "런닝메이트";
@@ -185,6 +171,11 @@ export const CreatedRunsSection = ({
         <EmptyState text="생성한 러닝이 없습니다." />
       ) : (
         <View style={styles.cardListWrapper}>
+          {/* TODO: [마이페이지 UI 개선] 
+              1. CANCELED 상태인 방은 목록에서 보이지 않도록 .filter 적용 필요
+              2. subtitle에 상태값(OPEN, CLOSED 등)에 따른 텍스트 변환 헬퍼 함수 적용 필요
+              3. FINISHED 상태일 경우 rightElement의 '관리' 버튼을 '평가하기' 버튼으로 변경 필요
+          */}
           {runs.map((run) => (
             <MyPageCard
               key={run.id}

--- a/src/components/mypage/Sections.tsx
+++ b/src/components/mypage/Sections.tsx
@@ -1,3 +1,4 @@
+import { router } from "expo-router";
 import { View, Text, ActivityIndicator } from "react-native";
 
 import { Button } from "../common/button/Button";
@@ -151,10 +152,11 @@ export const CreatedRunsSection = ({
   isError,
   onRetry,
 }: SectionsProps<CreatedRunning[]>) => {
-  // TODO: 호스트 전용 러닝 관리 페이지 네비게이션 연결
-  const handleManageRun = (runningId: number) => {
-    // eslint-disable-next-line no-console
-    console.log(`러닝 관리 페이지 이동: ${runningId}`);
+  const handleManageRun = (sessionId: number, runTitle: string) => {
+    router.push({
+      pathname: "/manage-participants",
+      params: { id: sessionId, title: runTitle },
+    });
   };
 
   if (isFetching && runs.length === 0) {
@@ -192,7 +194,7 @@ export const CreatedRunsSection = ({
                 <Button
                   variant="primary"
                   size="sm"
-                  onPress={() => handleManageRun(run.id)}
+                  onPress={() => handleManageRun(run.id, run.title)}
                 >
                   관리
                 </Button>

--- a/src/constants/mappings.ts
+++ b/src/constants/mappings.ts
@@ -1,0 +1,10 @@
+import { colors } from "./theme";
+
+export const GENDER_MAP: Record<string, string> = {
+  MALE: "남성",
+  FEMALE: "여성",
+};
+
+export const getGenderColor = (gender: string) => {
+  return gender === "MALE" ? colors.main : colors.red600;
+};

--- a/src/constants/mappings.ts
+++ b/src/constants/mappings.ts
@@ -8,3 +8,11 @@ export const GENDER_MAP: Record<string, string> = {
 export const getGenderColor = (gender: string) => {
   return gender === "MALE" ? colors.main : colors.red600;
 };
+
+export const AGEGROUPMAP: Record<string, string> = {
+  "10S": "10대",
+  "20S": "20대",
+  "30S": "30대",
+  "40S": "40대",
+  "50S": "50대",
+};

--- a/src/types/api/manageParticipants.ts
+++ b/src/types/api/manageParticipants.ts
@@ -1,0 +1,14 @@
+import { Gender } from "./auth";
+
+export type requestStatus = "REQUESTED" | "APPROVED" | "REJECTED" | "CANCELED";
+
+export interface JoinRequest {
+  id: number;
+  userId: number;
+  userName: string;
+  userGender: Gender;
+  status: requestStatus;
+  attendanceStatus: string;
+  messageToHost: string;
+  requestedAt: string;
+}

--- a/src/types/api/manageParticipants.ts
+++ b/src/types/api/manageParticipants.ts
@@ -1,13 +1,13 @@
 import { Gender } from "./auth";
 
-export type requestStatus = "REQUESTED" | "APPROVED" | "REJECTED" | "CANCELED";
+export type RequestStatus = "REQUESTED" | "APPROVED" | "REJECTED" | "CANCELED";
 
 export interface JoinRequest {
   id: number;
   userId: number;
   userName: string;
   userGender: Gender;
-  status: requestStatus;
+  status: RequestStatus;
   attendanceStatus: string;
   messageToHost: string;
   requestedAt: string;


### PR DESCRIPTION
## 📣 Related Issue
- close #33 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- **참여자 관리 전체 UI 및 상태별 조건부 렌더링 구현**: 대기 멤버와 확정 멤버 리스트 화면을 구현하고, 세션의 현재 모집 상태에 따라 하단 액션 바의 버튼들이 동적으로 렌더링되도록 로직을 분리했습니다.
- **쿼리 키 팩토리 패턴 도입**: 하드코딩된 문자열 사용 시 발생할 수 있는 오타 버그를 방지하고 유지보수성을 높이기 위해, 쿼리 키를 객체 형태로 중앙 집중화하여 관리하는 팩토리 패턴을 적용했습니다. 데이터 변경 시 상위 키를 무효화하여 연관된 하위 캐시가 한 번에 갱신되도록 전략을 최적화했습니다.
- **통신 상태값을 활용한 중복 클릭 원천 방어**: 유저 수락 및 거절 액션 시, 통신 중인 로딩 상태값을 컴포넌트 내부로 가져와 버튼의 비활성화 속성에 연결했습니다. 이를 통해 사용자의 연속 클릭이나 네트워크 지연 시 발생할 수 있는 중복 요청 문제를 프론트엔드 단에서 안전하게 차단했습니다.
- **인메모리 기반 동적 가짜 데이터 서버 구축**: 버튼 액션 발생 시 내부 배열 데이터를 직접 삭제하거나 이동시키도록 상태 조작 로직을 고도화했습니다. 백엔드 연동 전에도 실제 서비스와 완벽히 동일한 UI 흐름과 캐시 무효화를 테스트할 수 있습니다.
- **로컬 상태 업데이트 및 예외 처리 방어 로직 추가**: 모집 마감 전 출석 체크로 넘어가는 것을 막는 알림 예외 처리를 추가했습니다. 또한 모집 마감 성공 시 무거운 데이터를 다시 불러오는 대신, 내부 로컬 상태를 업데이트하여 화면이 반응하도록 사용자 경험을 최적화했습니다.

## 🖼 스크린샷(UI 변경시)
<img width="674" height="1498" alt="참여자 관리 UI" src="https://github.com/user-attachments/assets/975ee7ca-ac40-4e3a-a2c3-c5d97ce00835" />

<img width="672" height="554" alt="참여자 관리 확정 멤버 UI" src="https://github.com/user-attachments/assets/4325a54b-ce50-4d87-a8df-2607964223eb" />


## 🙏 Question & PR point
- 마이페이지에서 참여자 관리로 넘어올 때 상태 파라미터가 누락되어 초기 화면에 모집 마감 버튼이 뜨지 않는 이슈를 발견했습니다. 이 부분은 다음 마이페이지 리팩토링 티켓에서 라우팅 구조를 전면 수정할 때 함께 반영하는 것이 맞다고 판단하여, 이번 범위에서는 반영하지 않았습니다. 이러한 작업 분리 방향성에 대해 괜찮은 지 말씀 해주세요.
- 상태 관리 라이브러리를 사용할 때 기존처럼 쿼리 키를 배열에 직접 작성하지 않고 팩토리 패턴을 도입해 보았습니다. 코드를 읽어보시고, 프로젝트 규모가 커질 것을 대비해 추후 다른 화면 도메인 개발 시에도 이 아키텍처를 우리 팀의 표준 규칙으로 가져가면 어떨지 중점적으로 리뷰해 주시면 감사하겠습니다.
- 실제 서비스 운영 중 서버 통신 지연 상황을 고려해 가짜 서버 응답에 의도적인 지연 시간을 주어 테스트 환경을 구성했습니다. 버튼 클릭 시 비활성화가 걸리고 풀리는 흐름이 어색하지 않고 자연스러운지 테스트해 보시고 피드백 부탁드립니다.

