### PR TITLE
[FEAT] 출석 체크 페이지 UI 구현 및 상태 관리 아키텍처 적용

### DIFF
--- a/app/(main)/_layout.tsx
+++ b/app/(main)/_layout.tsx
@@ -108,6 +108,24 @@ export default function MainLayout() {
           headerLeft: () => <StackHeaderBack />,
         }}
       />
+      <Tabs.Screen
+        name="attendance"
+        options={{
+          href: null,
+          title: "출석 체크",
+          tabBarStyle: { display: "none" },
+          headerLeft: () => <StackHeaderBack />,
+        }}
+      />
+      <Tabs.Screen
+        name="manage-attendance"
+        options={{
+          href: null,
+          title: "참여자 관리",
+          tabBarStyle: { display: "none" },
+          headerLeft: () => <StackHeaderBack />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(main)/attendance.tsx
+++ b/app/(main)/attendance.tsx
@@ -1,33 +1,422 @@
-import { StyleSheet, Text, View } from "react-native";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { router, Tabs, useLocalSearchParams } from "expo-router";
+import React, { useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ActivityIndicator,
+  Alert,
+  FlatList,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
-import { colors, fontSizes, fontWeights, spacing } from "@/src/constants";
+import { attendanceKey } from "@/src/api/attendance/attendance.keys";
+import {
+  getAttendance,
+  updateAttendance,
+} from "@/src/api/attendance/attendanceApi.index";
+import { getSessionDetail } from "@/src/api/session-detail/sessionDetailApi.index";
+import AttendanceSvg from "@/src/assets/icon/attendance/attendance.svg";
+import AttendanceCalendarSvg from "@/src/assets/icon/attendance/attendanceCalendar.svg";
+import AttendanceMemberCard from "@/src/components/attendance/AttendanceMemberCard";
+import { Button } from "@/src/components/common/button/Button";
+import Chip from "@/src/components/common/chip";
+import {
+  colors,
+  fontSizes,
+  fontWeights,
+  spacing,
+  borderRadius,
+} from "@/src/constants";
+import { AttendanceMember, AttendanceStatus } from "@/src/types/api/attendance";
+import { CreatedRunningResponse } from "@/src/types/api/mypage";
+import { formatDate } from "@/src/utils/date";
 
 export default function AttendanceScreen() {
+  // 임시 저장소 (누를 때마다 API 호출 없이 변경된 출석 상태 저장)
+  const [pendingChanges, setPendingChanges] = useState<
+    Record<number, AttendanceStatus>
+  >({});
+  const queryClient = useQueryClient();
+
+  const { id } = useLocalSearchParams<{
+    id: string;
+  }>();
+
+  const sessionId = Number(id);
+
+  // 마이페이지 캐시에서 세션 정보 가져와 헤더 즉시 렌더링
+  const { data: sessionInfo } = useQuery({
+    queryKey: ["sessionDetail", sessionId],
+    queryFn: async () => {
+      const response = await getSessionDetail(sessionId);
+      return {
+        title: response.title,
+        date: response.startAt,
+      };
+    },
+    initialData: () => {
+      const appliedRuns = queryClient.getQueryData<CreatedRunningResponse>([
+        "myPage",
+        "createdRuns",
+      ]);
+
+      const cachedSession = appliedRuns?.find((run) => run.id === sessionId);
+
+      if (cachedSession) {
+        return {
+          title: cachedSession.title,
+          date: cachedSession.startAt,
+        };
+      }
+
+      return undefined;
+    },
+  });
+
+  const title = sessionInfo?.title ?? "";
+  const date = sessionInfo?.date ?? "";
+
+  // 원본 출석 데이터 패칭
+  const { data, isError, isLoading } = useQuery({
+    queryKey: attendanceKey.all(sessionId),
+    queryFn: () => getAttendance(sessionId),
+  });
+
+  // Promise.all을 활용한 출석 상태 병렬 업데이트
+  const updateAttendanceMutation = useMutation({
+    mutationFn: async (changes: Record<number, AttendanceStatus>) => {
+      const promises = Object.entries(changes).map(([pId, status]) => {
+        return updateAttendance({
+          sessionId,
+          participationId: Number(pId),
+          status,
+        });
+      });
+      return Promise.all(promises);
+    },
+
+    onSuccess: () => {
+      setPendingChanges({});
+      queryClient.invalidateQueries({ queryKey: ["attendance", sessionId] });
+
+      // 성공 시 출석 관리 화면 이동
+      router.push({
+        pathname: "/manage-attendance",
+        params: { id: sessionId },
+      });
+    },
+    onError: (error) => {
+      console.error("출석 업데이트 중 에러 발생:", error);
+      // 무한 루프 방지 및 재시도 유도
+      Alert.alert(
+        "출석 업데이트에 실패하였습니다.",
+        "잠시후 다시 시도해주세요",
+        [
+          {
+            text: "확인",
+          },
+        ],
+      );
+    },
+  });
+
+  const onRefresh = async () => {
+    queryClient.invalidateQueries({ queryKey: attendanceKey.all(sessionId) });
+  };
+
+  // 원본 데이터 캐싱
+  const members = React.useMemo(() => {
+    return data ?? [];
+  }, [data]);
+
+  // 화면 표시용 데이터
+  const displayMembers = React.useMemo(() => {
+    return members.map((member) => ({
+      ...member,
+      attendanceStatus: pendingChanges[member.id] ?? member.attendanceStatus,
+    }));
+  }, [members, pendingChanges]);
+
+  const totalCount = members.length;
+
+  // 현재 출석 인원 카운트
+  const attendedCount = React.useMemo(() => {
+    return displayMembers.filter((m) => m.attendanceStatus === "ATTENDED")
+      .length;
+  }, [displayMembers]);
+
+  // 출석 토글 핸들러
+  const handleToggleStatus = React.useCallback(
+    (participationId: number, currentStatus: AttendanceStatus) => {
+      setPendingChanges((prev) => {
+        const newStatus = currentStatus === "ATTENDED" ? "ABSENT" : "ATTENDED";
+
+        const originalStatus = members.find(
+          (m) => m.id === participationId,
+        )?.attendanceStatus;
+
+        const nextChanges = { ...prev };
+
+        // 원본 상태와 동일해지면 임시 저장소에서 삭제
+        if (originalStatus === newStatus) {
+          delete nextChanges[participationId];
+        } else {
+          nextChanges[participationId] = newStatus;
+        }
+
+        return nextChanges;
+      });
+    },
+    [members],
+  );
+
+  // FlatList 아이템 렌더링 함수
+  const renderAttendanceItem = React.useCallback(
+    ({ item, index }: { item: AttendanceMember; index: number }) => {
+      const isLastItem = index === displayMembers.length - 1;
+
+      return (
+        // 첫 아이템과 끝 아이템 개별 라운딩 처리
+        <View
+          style={[
+            styles.flatListItem,
+            index === 0 && styles.flatListFirstItem,
+            isLastItem && styles.flatListLastItem,
+          ]}
+        >
+          <AttendanceMemberCard
+            participant={item}
+            isLastItem={isLastItem}
+            onToggleStatus={handleToggleStatus}
+          />
+        </View>
+      );
+    },
+    [displayMembers.length, handleToggleStatus],
+  );
+
+  // FlatList 헤더 JSX 캐싱
+  const listHeader = React.useMemo(
+    () => (
+      <View style={styles.listHeader}>
+        <View style={styles.listHeaderLeft}>
+          <AttendanceSvg width={24} height={24} />
+          <Text style={styles.listTitle}>참여 예정 멤버 ({totalCount}명)</Text>
+        </View>
+        <Chip
+          label={`현재 ${attendedCount}명 출석`}
+          color="primary"
+          size="small"
+          variant="filled"
+        />
+      </View>
+    ),
+    [totalCount, attendedCount],
+  );
+
+  // FlatList 푸터 JSX 캐싱
+  const listFooter = React.useMemo(
+    () => (
+      <View style={styles.infoBox}>
+        <Text style={styles.infoText}>
+          💡 모든 멤버의 출석 여부를 확인한 후 출석 완료 버튼을 눌러주세요.
+          출석이 완료되면 러닝 세션이 공식적으로 시작됩니다.
+        </Text>
+      </View>
+    ),
+    [],
+  );
+
+  if (isLoading) {
+    return (
+      <SafeAreaView
+        style={[
+          styles.container,
+          { justifyContent: "center", alignItems: "center" },
+        ]}
+      >
+        <ActivityIndicator size="large" color={colors.primary} />
+        <Text style={styles.loadingText}>참여자 명단을 불러오는 중입니다</Text>
+      </SafeAreaView>
+    );
+  }
+
+  if (isError) {
+    return (
+      <View style={styles.centerBox}>
+        <Text style={styles.errorText}>참여자 명단을 불러오지 못했습니다.</Text>
+        <Button variant="outline" size="sm" onPress={onRefresh}>
+          다시 시도
+        </Button>
+      </View>
+    );
+  }
+
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>출석 관리</Text>
-      <Text style={styles.hint}>
-        `/attendance`에 대응하는 화면입니다. (준비 중)
-      </Text>
-    </View>
+    <SafeAreaView style={styles.safeArea}>
+      <Tabs.Screen
+        options={{
+          headerTitle: () => (
+            <View style={styles.headerTitleContainer}>
+              <Text style={styles.headerMainText}>출석 체크</Text>
+              <View style={styles.headerSubTextContainer}>
+                <AttendanceCalendarSvg width={14} height={14} />
+                <Text style={styles.headerSubText}>
+                  {formatDate(date)} | {title}
+                </Text>
+              </View>
+            </View>
+          ),
+        }}
+      />
+
+      {/* MIDDLE 영역 */}
+      <FlatList
+        data={displayMembers}
+        keyExtractor={(item) => item.userId.toString()}
+        renderItem={renderAttendanceItem}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+        ListHeaderComponent={listHeader}
+        ListHeaderComponentStyle={{ marginBottom: 12 }}
+        ListFooterComponent={listFooter}
+        ListFooterComponentStyle={{ marginTop: 24 }}
+        // FlatList 성능 및 메모리 관리 튜닝 옵션
+        initialNumToRender={15}
+        maxToRenderPerBatch={10}
+        windowSize={5}
+      />
+
+      {/* BOTTOM 영역 */}
+      <View style={styles.bottomFixedArea}>
+        <Button
+          variant="primary"
+          size="lg"
+          fullWidth
+          disabled={updateAttendanceMutation.isPending}
+          onPress={() => {
+            const hasChanges = Object.keys(pendingChanges).length > 0;
+
+            // 변경 내역 존재 여부에 따른 분기 처리 (내역 없으면 즉시 관리 화면 이동)
+            if (hasChanges) {
+              updateAttendanceMutation.mutate(pendingChanges);
+            } else {
+              router.push({
+                pathname: "/manage-attendance",
+                params: { id: sessionId },
+              });
+            }
+          }}
+        >
+          {updateAttendanceMutation.isPending
+            ? "처리 중..."
+            : "출석 완료 및 러닝 시작"}
+        </Button>
+      </View>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    padding: spacing.lg,
     backgroundColor: colors.bgSecondary,
+  },
+  loadingText: {
+    marginTop: spacing.md,
+    color: colors.textSecondary,
+  },
+  centerBox: {
+    alignItems: "center",
+  },
+  errorText: {
+    color: colors.error,
+  },
+  safeArea: {
+    flex: 1,
+    backgroundColor: colors.bgSecondary,
+  },
+
+  // ============ Header ============
+  headerTitleContainer: {
+    alignItems: "center",
     justifyContent: "center",
   },
-  title: {
-    fontSize: fontSizes.xl,
+  headerMainText: {
+    fontSize: fontSizes.lg,
     fontWeight: fontWeights.bold,
-    color: colors.text,
-    marginBottom: spacing.sm,
+    color: colors.gray600,
   },
-  hint: {
+  headerSubTextContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginTop: spacing.xxs,
+    gap: spacing.xs,
+  },
+
+  headerSubText: {
     fontSize: fontSizes.sm,
     color: colors.textSecondary,
+  },
+
+  // ============ FlatList Item ============
+  flatListItem: {
+    backgroundColor: colors.bg,
+  },
+  flatListFirstItem: {
+    borderTopLeftRadius: borderRadius.xl,
+    borderTopRightRadius: borderRadius.xl,
+    overflow: "hidden",
+  },
+  flatListLastItem: {
+    borderBottomLeftRadius: borderRadius.xl,
+    borderBottomRightRadius: borderRadius.xl,
+    overflow: "hidden",
+  },
+
+  // ============ List Content ============
+  scrollContent: {
+    padding: 20,
+    paddingBottom: spacing.xxl,
+  },
+  listHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: spacing.md,
+  },
+  listHeaderLeft: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  listTitle: {
+    fontSize: fontSizes.base,
+    fontWeight: fontWeights.bold,
+    color: colors.gray700,
+    marginLeft: spacing.sm,
+  },
+
+  // ============ Info Box ============
+  infoBox: {
+    backgroundColor: colors.mainLight,
+    padding: spacing.base,
+    borderRadius: borderRadius.lg,
+  },
+  infoText: {
+    fontSize: fontSizes.sm,
+    lineHeight: 20,
+    color: colors.primary,
+  },
+
+  // ============ Bottom Area ============
+  bottomFixedArea: {
+    backgroundColor: colors.bg,
+    paddingHorizontal: 20,
+    paddingTop: spacing.md,
+    paddingBottom: spacing.lg,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
   },
 });

--- a/app/(main)/manage-attendance.tsx
+++ b/app/(main)/manage-attendance.tsx
@@ -1,0 +1,33 @@
+import { StyleSheet, Text, View } from "react-native";
+
+import { colors, fontSizes, fontWeights, spacing } from "@/src/constants";
+
+export default function ManageAttendanceScreen() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>참여자 관리</Text>
+      <Text style={styles.hint}>
+        `/manage-attendance`에 대응하는 화면입니다. (준비 중)
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: spacing.lg,
+    backgroundColor: colors.bgSecondary,
+    justifyContent: "center",
+  },
+  title: {
+    fontSize: fontSizes.xl,
+    fontWeight: fontWeights.bold,
+    color: colors.text,
+    marginBottom: spacing.sm,
+  },
+  hint: {
+    fontSize: fontSizes.sm,
+    color: colors.textSecondary,
+  },
+});

--- a/src/api/attendance/attendance.keys.ts
+++ b/src/api/attendance/attendance.keys.ts
@@ -1,0 +1,3 @@
+export const attendanceKey = {
+  all: (sessionId: number) => ["attendance", sessionId] as const,
+};

--- a/src/api/attendance/attendanceApi.index.ts
+++ b/src/api/attendance/attendanceApi.index.ts
@@ -1,0 +1,16 @@
+import {
+  getAttendance as realGetAttendance,
+  updateAttendance as realUpdateAttendance,
+} from "./attendanceApi";
+import {
+  getAttendance as mockGetAttendance,
+  updateAttendance as mockUpdateAttendance,
+} from "./attendanceApi.mock";
+
+const isMock = process.env.EXPO_PUBLIC_USE_MOCK === "true";
+
+export const getAttendance = isMock ? mockGetAttendance : realGetAttendance;
+
+export const updateAttendance = isMock
+  ? mockUpdateAttendance
+  : realUpdateAttendance;

--- a/src/api/attendance/attendanceApi.index.ts
+++ b/src/api/attendance/attendanceApi.index.ts
@@ -9,8 +9,18 @@ import {
 
 const isMock = process.env.EXPO_PUBLIC_USE_MOCK === "true";
 
+/**
+ * 출석부(참여 멤버 목록) 조회
+ * @param sessionId - 출석 상태를 조회할 러닝 세션의 고유 ID
+ * @returns 해당 세션에 승인된 참여자 목록 및 현재 출석 상태 (AttendanceMember 배열)
+ */
 export const getAttendance = isMock ? mockGetAttendance : realGetAttendance;
 
+/**
+ * 단일 멤버 출석 상태 업데이트
+ * @param params - 세션 ID, 참여 번호(participationId), 변경할 출석 상태(ATTENDED | ABSENT)
+ * @returns 상태 업데이트 성공 여부 및 결과 데이터
+ */
 export const updateAttendance = isMock
   ? mockUpdateAttendance
   : realUpdateAttendance;

--- a/src/api/attendance/attendanceApi.mock.ts
+++ b/src/api/attendance/attendanceApi.mock.ts
@@ -1,0 +1,65 @@
+import {
+  UpdateAttendanceParams,
+  AttendanceMember,
+} from "@/src/types/api/attendance";
+
+// Mock 데이터
+let mockAttendanceList: AttendanceMember[] = [
+  {
+    userId: 1,
+    userName: "박서준",
+    attendanceStatus: "ABSENT",
+  },
+  {
+    userId: 2,
+    userName: "김지은",
+    attendanceStatus: "ABSENT",
+  },
+  {
+    userId: 3,
+    userName: "이민호",
+    attendanceStatus: "ATTENDED",
+  },
+  {
+    userId: 4,
+    userName: "최유리",
+    attendanceStatus: "ABSENT",
+  },
+] as AttendanceMember[];
+
+/**
+ * [MOCK] 출석부(참여 멤버 목록) 조회
+ */
+export const getAttendance = async (
+  _sessionId: number,
+): Promise<AttendanceMember[]> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(mockAttendanceList);
+    }, 500);
+  });
+};
+
+/**
+ * [MOCK] 단일 멤버 출석 상태 업데이트
+ */
+export const updateAttendance = async ({
+  // sessionId,
+  participationId,
+  status,
+}: UpdateAttendanceParams) => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      mockAttendanceList = mockAttendanceList.map((member) =>
+        member.userId === participationId
+          ? { ...member, attendanceStatus: status }
+          : member,
+      );
+
+      resolve({
+        success: true,
+        message: "출석 상태가 성공적으로 변경되었습니다.",
+      });
+    }, 500);
+  });
+};

--- a/src/api/attendance/attendanceApi.ts
+++ b/src/api/attendance/attendanceApi.ts
@@ -1,0 +1,26 @@
+import { axiosInstance } from "../axiosInstance";
+
+import {
+  UpdateAttendanceParams,
+  AttendanceMember,
+} from "@/src/types/api/attendance";
+
+export const getAttendance = async (
+  sessionId: number,
+): Promise<AttendanceMember[]> => {
+  const response = await axiosInstance.get<AttendanceMember[]>(
+    `/sessions/${sessionId}/attendance`,
+  );
+  return response.data;
+};
+
+export const updateAttendance = async ({
+  sessionId,
+  participationId,
+  status,
+}: UpdateAttendanceParams) => {
+  const url = `/sessions/${sessionId}/participants/${participationId}/attendance`;
+  const response = await axiosInstance.patch(url, { attendanceStatus: status });
+
+  return response.data;
+};

--- a/src/assets/icon/attendance/attendance.svg
+++ b/src/assets/icon/attendance/attendance.svg
@@ -1,0 +1,13 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_60_2147)">
+<path d="M13.3304 17.4966V15.8302C13.3304 14.9464 12.9793 14.0987 12.3543 13.4737C11.7293 12.8487 10.8816 12.4976 9.99772 12.4976H4.9987C4.11482 12.4976 3.26713 12.8487 2.64214 13.4737C2.01714 14.0987 1.66602 14.9464 1.66602 15.8302V17.4966" stroke="#2B7FFF" stroke-width="1.66634" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7.4987 9.16488C9.33929 9.16488 10.8314 7.67278 10.8314 5.83219C10.8314 3.9916 9.33929 2.49951 7.4987 2.49951C5.65811 2.49951 4.16602 3.9916 4.16602 5.83219C4.16602 7.67278 5.65811 9.16488 7.4987 9.16488Z" stroke="#2B7FFF" stroke-width="1.66634" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M18.3296 17.4967V15.8303C18.329 15.0919 18.0833 14.3746 17.6309 13.791C17.1785 13.2074 16.545 12.7906 15.8301 12.606" stroke="#2B7FFF" stroke-width="1.66634" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M13.3311 2.60791C14.0479 2.79146 14.6833 3.20838 15.1371 3.79294C15.5908 4.3775 15.8371 5.09645 15.8371 5.83645C15.8371 6.57644 15.5908 7.29539 15.1371 7.87995C14.6833 8.46451 14.0479 8.88143 13.3311 9.06498" stroke="#2B7FFF" stroke-width="1.66634" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_60_2147">
+<rect width="19.9961" height="19.9961" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/assets/icon/attendance/attendanceCalendar.svg
+++ b/src/assets/icon/attendance/attendanceCalendar.svg
@@ -1,0 +1,13 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_60_2134)">
+<path d="M5.32715 1.33203V3.99573" stroke="#99A1AF" stroke-width="1.33185" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M10.6553 1.33203V3.99573" stroke="#99A1AF" stroke-width="1.33185" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12.6529 2.66357H3.3299C2.59434 2.66357 1.99805 3.25986 1.99805 3.99542V13.3184C1.99805 14.0539 2.59434 14.6502 3.3299 14.6502H12.6529C13.3884 14.6502 13.9847 14.0539 13.9847 13.3184V3.99542C13.9847 3.25986 13.3884 2.66357 12.6529 2.66357Z" stroke="#99A1AF" stroke-width="1.33185" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M1.99805 6.65918H13.9847" stroke="#99A1AF" stroke-width="1.33185" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_60_2134">
+<rect width="15.9822" height="15.9822" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/attendance/AttendanceMemberCard.tsx
+++ b/src/components/attendance/AttendanceMemberCard.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+
+import { Button } from "../common/button/Button";
+
+import { colors, fontSizes, fontWeights, spacing } from "@/src/constants";
+import { getGenderColor } from "@/src/constants/mappings";
+import { AttendanceMember, AttendanceStatus } from "@/src/types/api/attendance";
+
+interface AttendanceMemberCardProps {
+  participant: AttendanceMember;
+  onToggleStatus: (
+    participationId: number,
+    currentStatus: AttendanceStatus,
+  ) => void;
+  isLastItem?: boolean;
+}
+
+const AttendanceMemberCard = ({
+  participant,
+  onToggleStatus,
+  isLastItem = false,
+}: AttendanceMemberCardProps) => {
+  const isAttended = participant.attendanceStatus === "ATTENDED";
+
+  return (
+    <View style={[styles.container, !isLastItem && styles.bottomBorder]}>
+      <View style={styles.profileSection}>
+        <View
+          style={[
+            styles.avatar,
+            { backgroundColor: getGenderColor(participant.userGender) },
+          ]}
+        >
+          <Text style={styles.avatarText}>
+            {participant.userName.charAt(0)}
+          </Text>
+        </View>
+        <View style={styles.infoContainer}>
+          <Text style={styles.nameText}>{participant.userName}</Text>
+        </View>
+      </View>
+
+      <Button
+        variant={isAttended ? "primary" : "outline"}
+        size="sm"
+        rounded={true}
+        wrapperStyle={{ minWidth: 80 }}
+        onPress={() =>
+          onToggleStatus(participant.id, participant.attendanceStatus)
+        }
+      >
+        {isAttended ? "출석" : "미출석"}
+      </Button>
+    </View>
+  );
+};
+
+export default React.memo(AttendanceMemberCard, (prevProps, nextProps) => {
+  return (
+    prevProps.participant.attendanceStatus ===
+      nextProps.participant.attendanceStatus &&
+    prevProps.isLastItem === nextProps.isLastItem
+  );
+});
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: spacing.base,
+    paddingHorizontal: spacing.lg,
+    backgroundColor: colors.bg,
+  },
+  profileSection: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: spacing.md,
+  },
+  bottomBorder: {
+    borderBottomWidth: 1,
+    borderBottomColor: colors.bgSecondary,
+  },
+  leftSection: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  avatar: {
+    width: spacing.xxxl,
+    height: spacing.xxxl,
+    borderRadius: 24,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  avatarText: {
+    color: colors.white,
+    fontSize: fontSizes.md,
+    fontWeight: fontWeights.bold,
+  },
+
+  infoContainer: {
+    flexDirection: "column",
+    justifyContent: "center",
+    gap: spacing.xs,
+  },
+  nameText: {
+    fontSize: fontSizes.md,
+    fontWeight: fontWeights.bold,
+    color: colors.text,
+  },
+});

--- a/src/types/api/attendance.ts
+++ b/src/types/api/attendance.ts
@@ -1,0 +1,11 @@
+import { JoinRequest } from "./manageParticipants";
+
+export type AttendanceStatus = "ATTENDED" | "ABSENT";
+
+export interface UpdateAttendanceParams {
+  sessionId: number;
+  participationId: number;
+  status: AttendanceStatus;
+}
+
+export type AttendanceMember = JoinRequest;

--- a/src/types/api/manageParticipants.ts
+++ b/src/types/api/manageParticipants.ts
@@ -1,3 +1,4 @@
+import { AttendanceStatus } from "./attendance";
 import { Gender } from "./auth";
 
 export type RequestStatus = "REQUESTED" | "APPROVED" | "REJECTED" | "CANCELED";
@@ -8,7 +9,7 @@ export interface JoinRequest {
   userName: string;
   userGender: Gender;
   status: RequestStatus;
-  attendanceStatus: string;
+  attendanceStatus: AttendanceStatus;
   messageToHost: string;
   requestedAt: string;
 }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
<!-- 아직 완전 해결이 아닌 경우 `partially fixes #번호` 사용 -->
- close #35 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- **출석 체크 메인 화면 및 UI 컴포넌트 구현**
  - 성별 프로필 색상이 반영된 `AttendanceMemberCard` 컴포넌트 분리 및 개발
  - 새로운 탭 라우팅(`AttendanceScreen`, `ManageAttendanceScreen`) 추가 및 연결
- **렌더링 성능 최적화 (대용량 리스트 대비)**
  - 추후 러닝 인원 확장을 고려하여 `ScrollView` 대신 `FlatList`를 도입해 가상화(Virtualization) 적용
  - `React.memo` (커스텀 `areEqual` 포함)와 `useCallback`을 활용해 토글 시 해당 멤버 카드 딱 1장만 리렌더링되도록 방어
- **장바구니 패턴 도입 (API 최적화)**
  - 출석 상태 토글 시마다 API를 쏘지 않고, `pendingChanges` 상태에 모아두었다가 하단 버튼 클릭 시 `Promise.all`로 일괄 업데이트
  - 변경 후 원본 상태로 되돌리면(예: 출석 -> 미출석 -> 출석) `pendingChanges`에서 삭제하여 불필요한 API 통신 원천 차단
- **출석 관련 API 계층(Layer) 구현 및 문서화**
  - 출석 조회/업데이트 API 연동 및 환경 변수에 따른 Mock 데이터 분기 처리
  - JSDoc을 활용하여 함수 명세서(파라미터, 반환값) 작성 추가

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야 할 사항이나 궁금증을 적어주세요 -->
- **렌더링 최적화 리뷰 부탁드립니다! **
  - 처음에는 단순히 `.map()`으로 렌더링하다가 리렌더링 최적화를 위해 `FlatList`로 구조를 전면 수정했습니다. 
  - `renderAttendanceItem` 함수 재생성과 `ListHeaderComponent`의 깜빡임을 막기 위해 `useMemo`와 `useCallback`을 적극적으로 사용했는데, 리액트 라이프사이클 관점에서 훅(Hook)들이 올바르게 배치되었는지, 더 개선할 점은 없는지 꼼꼼한 코드 리뷰 부탁드립니다!
- **Promise.all을 활용한 병렬 통신 구조 리뷰 부탁드립니다! **
  - 여러 명의 출석 상태를 한 번에 업데이트하기 위해 장바구니(`pendingChanges`)에 변경 내역을 모아두었다가, 하단 완료 버튼 클릭 시 `Promise.all`을 사용하여 다건의 API 요청을 병렬로 처리하도록 구현했습니다.
  - 현재처럼 단건 API를 프론트에서 묶어서 쏘는 구조가 적절한지 의견 및 리뷰 부탁드립니다!
- **Zero-Latency 진입 **
  - `useQuery`의 `initialData`를 활용하여 마이페이지 캐시에서 세션 정보를 미리 가져와 화면 진입 시 헤더가 딜레이 없이 즉시 보이도록 UX를 개선해 보았습니다.