### PR TITLE
fix: 내가 만든 러닝 상태별 관리 버튼 라우팅 누락 수정

### DIFF
--- a/src/components/mypage/Sections.tsx
+++ b/src/components/mypage/Sections.tsx
@@ -13,7 +13,11 @@ import MannerIcon from "@/src/assets/icon/my-page/manner.svg";
 import Chip from "@/src/components/common/chip";
 import { colors } from "@/src/constants/index";
 import { AGEGROUPMAP, GENDER_MAP } from "@/src/constants/mappings";
-import { CreatedRunning, UserProfile } from "@/src/types/api/mypage";
+import {
+  CreatedRunning,
+  RunningStatus,
+  UserProfile,
+} from "@/src/types/api/mypage";
 import {
   AppliedRunningsResponse,
   RecentRunningsResponse,
@@ -155,11 +159,40 @@ export const CreatedRunsSection = ({
 }: SectionsProps<CreatedRunning[]>) => {
   const router = useRouter();
 
-  const handleManageRun = (sessionId: number, runTitle: string) => {
-    router.push({
-      pathname: "/manage-participants",
-      params: { id: sessionId, title: runTitle },
-    });
+  const handleManageRun = (
+    sessionId: number,
+    runTitle: string,
+    status: RunningStatus,
+  ) => {
+    switch (status) {
+      case "OPEN":
+        // 모집 중인 상태: 참여자 관리 페이지
+        router.push({
+          pathname: "/manage-participants",
+          params: { id: sessionId, title: runTitle },
+        });
+        break;
+
+      case "CLOSED":
+        // 마감된 상태: 출석 페이지
+        router.push({
+          pathname: "/attendance",
+          params: { id: sessionId, title: runTitle },
+        });
+        break;
+
+      case "IN_PROGRESS":
+        // 러닝 진행 중인 상태: 출석 체크/관리 페이지
+        router.push({
+          pathname: "/manage-attendance",
+          params: { id: sessionId, title: runTitle },
+        });
+        break;
+
+      default:
+        console.warn("알 수 없는 러닝 상태입니다:", status);
+        break;
+    }
   };
 
   const handleRateMembers = (sessionId: number) => {
@@ -213,7 +246,9 @@ export const CreatedRunsSection = ({
                   <Button
                     variant="primary"
                     size="sm"
-                    onPress={() => handleManageRun(run.id, run.title)}
+                    onPress={() =>
+                      handleManageRun(run.id, run.title, run.status)
+                    }
                   >
                     관리
                   </Button>


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
<!-- 아직 완전 해결이 아닌 경우 `partially fixes #번호` 사용 -->
- close #43 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 마이페이지 '내가 만든 러닝' 목록에서 '관리' 버튼 클릭 시, 러닝의 상태(status)에 따라 알맞은 관리 페이지로 라우팅되도록 분기 처리를 구현했습니다.
- `OPEN`(모집 중) 상태: 참여자 관리 페이지(`/manage-participants`)로 이동
- `CLOSED`(모집 마감) 상태: 출석 페이지(`/attendance`)로 이동
- `IN_PROGRESS`(진행 중) 상태: 출석 관리 페이지(`/manage-attendance`)로 이동


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야 할 사항이나 궁금증을 적어주세요 -->
- `IN_PROGRESS` 상태일 때 `/manage-attendance`로 라우팅되도록 연결해 두었습니다. 기획상 출석 체크 페이지의 경로가 맞는지 한 번 확인 부탁드립니다!
- 버튼 클릭 시 상태 구분을 위해 `CreatedRunsSection`의 `handleManageRun` 함수 파라미터로 `status`를 추가로 넘겨주도록 구조를 변경했습니다.

