### PR TITLE
[FIX] 러닝 리스트 노출 필터링 조건 추가 (홈 화면)

### DIFF
--- a/src/components/nearbyList/NearbyList.tsx
+++ b/src/components/nearbyList/NearbyList.tsx
@@ -39,6 +39,11 @@ export function NearbyList({ x, y }: NearbyListProps) {
     }, [refetch]),
   );
 
+  const now = new Date();
+
+  const futureSessions =
+    sessions?.filter((session) => new Date(session.startAt) > now) || [];
+
   return (
     <View style={styles.outer}>
       <View style={styles.listHeader}>
@@ -59,7 +64,7 @@ export function NearbyList({ x, y }: NearbyListProps) {
             <Text style={styles.listMessage}>불러오는 중...</Text>
           </View>
         )}
-        {!loading && sessions?.length === 0 && (
+        {!loading && futureSessions.length === 0 && (
           <View style={styles.emptyBox}>
             <Text style={styles.listMessage}>
               현 위치 기준으로 조회된 러닝 세션이 없습니다.
@@ -67,9 +72,8 @@ export function NearbyList({ x, y }: NearbyListProps) {
           </View>
         )}
         {!loading &&
-          sessions &&
-          sessions.length > 0 &&
-          sessions.map((session) => (
+          futureSessions.length > 0 &&
+          futureSessions.map((session) => (
             <NearbyItem
               key={session.id}
               session={session}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
<!-- 아직 완전 해결이 아닌 경우 `partially fixes #번호` 사용 -->
- close #48 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- **홈 화면 러닝 세션 필터링 추가**: 내 주변 추천 러닝 목록(`NearbyList`)에서 이미 시작 시간(`startAt`)이 지난 과거 세션이 노출되지 않도록 제외하는 로직을 추가했습니다.
- **예정된 세션만 렌더링**: `new Date()`를 활용해 현재 시간과 비교하여 미래 시점의 세션(`futureSessions`)만 목록에 나타나도록 구현했습니다.
- **빈 상태(Empty State) UI 대응**: 필터링 결과 노출할 러닝 세션이 없을 경우 "현 위치 기준으로 조회된 러닝 세션이 없습니다."라는 안내 메시지가 정상적으로 보이도록 조건부 렌더링을 수정했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야 할 사항이나 궁금증을 적어주세요 -->
- 현재 사용자 기기의 시간(`new Date()`)을 기준으로 과거 세션을 제외하도록 구현했습니다. 혹시 서버 시간과의 오차나 타임존 관련해서 문제가 될 만한 부분이 있을지 확인 부탁드립니다.
- `sessions?.filter(...)` 로직을 컴포넌트 내부에서 처리했는데, 해당 방식이 괜찮은지 리뷰 부탁드립니다