### PR TITLE
[FIX] 러닝 개설 완료 시 라우팅 문제 수정 및 알림창(Alert) 피드백 추가

### DIFF
--- a/app/create-session.tsx
+++ b/app/create-session.tsx
@@ -3,6 +3,7 @@ import { AxiosError } from "axios";
 import { useRouter } from "expo-router";
 import { useState } from "react";
 import {
+  Alert,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
@@ -199,7 +200,12 @@ export default function CreateSessionScreen() {
       setError({});
       await createSession(requestBody);
       useCreateSessionDraftStore.getState().resetDraft();
-      router.back();
+      Alert.alert("안내", "러닝 개설이 완료되었습니다.", [
+        {
+          text: "확인",
+          onPress: () => router.replace("/(main)"),
+        },
+      ]);
     } catch (err) {
       const fallback = "세션 개설에 실패했습니다.";
       if (err instanceof AxiosError) {


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
<!-- 아직 완전 해결이 아닌 경우 `partially fixes #번호` 사용 -->
- close #50 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 러닝 개설 완료 후 이전 화면으로 이동(`router.back()`)하던 라우팅 문제를 홈 화면으로 이동하도록 수정했습니다.
- 사용자에게 성공 여부를 명확히 알리기 위해, 홈으로 이동하기 전 "러닝 개설이 완료되었습니다."라는 `Alert` 창을 띄우도록 UX를 개선했습니다.
- 이전 화면 스택을 남기지 않기 위해 Alert 확인 시 `router.replace('/(main)')`을 사용했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야 할 사항이나 궁금증을 적어주세요 -->
- 사용자가 개설 완료를 확실히 인지한 뒤 직접 홈으로 이동할 수 있도록 React Native의 기본 `Alert`을 활용했습니다. 
- Alert의 '확인' 버튼 클릭 시 메인 그룹 폴더인 `/(main)`으로 정상적으로 `replace` 되는지, 라우팅 흐름이 자연스러운지 확인 부탁드립니다
