### PR TITLE
[FIX] 401 에러 토큰 재발급 시 대기 큐 무한 루프 버그 수정 (BUG-004)

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -131,6 +131,7 @@ axiosInstance.interceptors.response.use(
         failedQueue.push({
           resolve: (token: string) => {
             originalRequest.headers.Authorization = `Bearer ${token}`;
+            originalRequest._retry = true;
             resolve(axiosInstance(originalRequest));
           },
           reject,

--- a/tests/auth-refresh.test.ts
+++ b/tests/auth-refresh.test.ts
@@ -96,7 +96,7 @@ describe("401 → 토큰 재발급", () => {
     expect(h.getAccessToken()).toBe("fresh-access");
   });
 
-  it.skip("★★ 재발급 후에도 401이면 각 요청은 정확히 1회만 재시도한다 (무한루프 방지) (BUG-004에서 해결 예정)", async () => {
+  it("★★ 재발급 후에도 401이면 각 요청은 정확히 1회만 재시도한다 (무한루프 방지)", async () => {
     let refreshCalls = 0;
     let protectedCalls = 0;
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
<!-- 아직 완전 해결이 아닌 경우 `partially fixes #번호` 사용 -->
- close #57 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 401 에러(인증 실패)로 인한 토큰 재발급 진행 중, 대기 큐(`failedQueue`)에 머물던 요청들이 무한 루프에 빠지는 버그(BUG-004)를 수정했습니다.
- 큐에 적재된 요청을 재시도할 때 `originalRequest._retry = true` 플래그 설정을 명시적으로 추가하여, 서버 문제 등으로 401 에러가 다시 발생하더라도 정확히 1회만 재시도되도록 로직을 보완했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야 할 사항이나 궁금증을 적어주세요 -->
- `src/api/axiosInstance.ts` 파일의 `isRefreshing` 조건문 내부, `failedQueue.push`의 `resolve` 콜백 함수에 추가된 `originalRequest._retry = true;` 구문을 확인해 주시면 됩니다.
- 핫픽스 적용 후, 무한 루프 방지 및 동시성 제어를 검증하는 `tests/auth-refresh.test.ts` 테스트 스위트가 모두 정상적으로 통과(9/9 passed)되었습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- 연관 버그 리포트: BUG-004 (재발급 대기 큐에서 재시도되는 요청에 _retry 플래그가 붙지 않는다)
