### PR TITLE
[FIX] 유틸리티 함수 입력 검증 버그 수정 및 테스트 정상화 (BUG-002, BUG-008

### DIFF
--- a/src/utils/pace.ts
+++ b/src/utils/pace.ts
@@ -3,18 +3,32 @@
  */
 export function paceStringToSeconds(value: string): number | null {
   const trimmed = value.trim().replace(/\s/g, "");
+
+  /** 숫자1~2자리:숫자2자리 형식만 허용 */
+  if (!/^\d{1,2}:\d{2}$/.test(trimmed)) {
+    return null;
+  }
+
   const parts = trimmed.split(":");
-  if (parts.length !== 2) return null;
 
   const min = parseInt(parts[0], 10);
   const sec = parseInt(parts[1], 10);
-  if (!Number.isInteger(min) || !Number.isInteger(sec)) return null;
-  if (sec < 0 || sec > 59) return null;
-  return min * 60 + sec;
+
+  if (sec > 59) return null;
+
+  const totalSeconds = min * 60 + sec;
+
+  if (totalSeconds < 120 || totalSeconds > 900) return null;
+
+  return totalSeconds;
 }
 
 /** 초 단위 숫자를 "mm:ss" 문자열로 변환 */
 export function secondsToPaceString(totalSeconds: number): string {
+  if (totalSeconds < 0) {
+    throw new Error("페이스 초 단위는 음수가 될 수 없습니다.");
+  }
+
   const min = Math.floor(totalSeconds / 60);
   const sec = totalSeconds % 60;
   return `${String(min).padStart(2, "0")}:${String(sec).padStart(2, "0")}`;

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,6 +1,6 @@
 /** 빈 값 여부 */
 export function isEmpty(value: unknown): boolean {
-  if (value === null) return true;
+  if (value === null || value === undefined) return true;
   if (typeof value === "string") {
     return value.trim().length === 0;
   }

--- a/tests/pace.test.ts
+++ b/tests/pace.test.ts
@@ -32,27 +32,27 @@ describe("paceStringToSeconds — 거부해야 하는 입력", () => {
 
 describe("paceStringToSeconds — 현재 실패 ★★ (실제 결함)", () => {
   // parseInt 가 "5abc" 를 5 로 읽는다
-  it.skip("영숫자 혼합을 거부한다 (BUG-002에서 해결 예정)", () => {
+  it("영숫자 혼합을 거부한다", () => {
     expect(paceStringToSeconds("5abc:30")).toBeNull(); // 현재 330
   });
 
   // 분(min)에 하한 검사가 없다 → 음수 페이스가 서버로 나간다
-  it.skip("음수 분을 거부한다 (BUG-002에서 해결 예정)", () => {
+  it("음수 분을 거부한다", () => {
     expect(paceStringToSeconds("-01:30")).toBeNull(); // 현재 -30
   });
 
   // 0초/km 페이스는 물리적으로 불가능
-  it.skip("0 페이스를 거부한다 (BUG-002에서 해결 예정)", () => {
+  it("0 페이스를 거부한다", () => {
     expect(paceStringToSeconds("0:0")).toBeNull(); // 현재 0
   });
 
   // "05:5" 는 5분 5초인가 5분 50초인가? 모호하면 거부해야 한다
-  it.skip("초가 2자리가 아니면 거부한다 (BUG-002에서 해결 예정)", () => {
+  it("초가 2자리가 아니면 거부한다", () => {
     expect(paceStringToSeconds("05:5")).toBeNull(); // 현재 305
   });
 
   // 러닝 페이스로 성립하는 범위 밖
-  it.skip("현실적인 범위(2:00~15:00) 밖을 거부한다 (BUG-002에서 해결 예정)", () => {
+  it("현실적인 범위(2:00~15:00) 밖을 거부한다", () => {
     expect(paceStringToSeconds("99:59")).toBeNull(); // 현재 5999
     expect(paceStringToSeconds("01:00")).toBeNull(); // 현재 60
   });
@@ -68,7 +68,7 @@ describe("secondsToPaceString", () => {
   });
 
   // 현재 실패: "-1:-30" 이라는 말이 안 되는 문자열이 나온다
-  it.skip("음수 입력을 방어한다 ★ (BUG-002에서 해결 예정)", () => {
+  it("음수 입력을 방어한다 ★", () => {
     expect(() => secondsToPaceString(-30)).toThrow();
   });
 });

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -18,7 +18,7 @@ describe("isEmpty", () => {
   // ★ 현재 실패: 이름과 달리 undefined 를 "비어있지 않다"고 판정한다.
   // 지금은 호출부가 전부 .trim() 을 걸어 넘겨서 안 터지지만,
   // API 응답의 undefined 를 그대로 넣는 호출부가 하나만 생기면 검증이 통째로 뚫린다.
-  it.skip("undefined → true ★ (BUG-008에서 해결 예정)", () => {
+  it("undefined → true ★", () => {
     expect(isEmpty(undefined)).toBe(true);
   });
 });


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
<!-- 아직 완전 해결이 아닌 경우 `partially fixes #번호` 사용 -->
- close #59 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- **BUG-008:** `isEmpty` 함수가 `undefined`를 빈 값으로 정상 인식하여 필터링하도록 예외 조건 추가 (`validation.ts`)
- **BUG-002:** `paceStringToSeconds` 함수에 영숫자 혼합/음수 입력을 차단하는 정규식(`/^\d{1,2}:\d{2}$/`) 적용 및 현실적인 페이스 유효 범위(2:00 ~ 15:00) 제한 로직 추가 (`pace.ts`)
- `secondsToPaceString` 함수에 음수 값이 들어올 경우 잘못된 문자열 변환을 막기 위해 에러를 발생시키도록(`throw Error`) 방어 로직 추가 (`pace.ts`)
- 비활성화되어 있던 유틸리티 테스트(`pace.test.ts`, `validation.test.ts`)의 skip을 해제하여 전체 테스트 통과 확인
## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야 할 사항이나 궁금증을 적어주세요 -->
- `paceStringToSeconds`의 페이스 입력 형식을 정규식으로 엄격하게 제한하여 잘못된 데이터(예: `5abc:30`, `-01:30`)가 API로 전송되는 것을 원천 차단했습니다.
- 테스트 요구사항에 맞추어 페이스 유효 범위를 2분(120초)에서 15분(900초)으로 제한했습니다. 혹시 기획상 이 범위를 벗어나는 페이스 입력(예: 걷기 등)을 허용해야 하는 엣지 케이스가 있을지 리뷰 때 한번 확인 부탁드립니다! 
- 이전 작업에서 skip 처리되었던 테스트들을 정상화하였습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- 연관 버그 리포트: (BUG-002, BUG-008)
