### PR TITLE
[FIX] 세션 생성 시 러닝 유형 및 성별 조건 미선택 오류 수정 (BUG-003)

### DIFF
--- a/app/create-session.tsx
+++ b/app/create-session.tsx
@@ -123,6 +123,14 @@ export default function CreateSessionScreen() {
 
     const next: Record<string, string> = {};
 
+    if (isEmpty(runType)) {
+      next.runType = "달리기 종류를 선택해주세요.";
+    }
+
+    if (isEmpty(genderPolicy)) {
+      next.genderPolicy = "참여 성별을 선택해주세요.";
+    }
+
     if (isEmpty(title.trim())) {
       next.title = "모임 이름을 입력해주세요.";
     }
@@ -175,6 +183,10 @@ export default function CreateSessionScreen() {
       return;
     }
 
+    if (runType === "" || genderPolicy === "") {
+      return;
+    }
+
     const distParsed = Number(targetDistanceKm.trim());
     const dist =
       Number.isFinite(distParsed) && distParsed > 0
@@ -183,7 +195,7 @@ export default function CreateSessionScreen() {
 
     const requestBody: CreateSessionRequest = {
       title: title.trim(),
-      runType: runType as RunType,
+      runType: runType,
       locationName: locationName.trim(),
       locationX: lon,
       locationY: lat,
@@ -192,7 +204,7 @@ export default function CreateSessionScreen() {
       avgPaceSec: paceSec!,
       startAt: startAt.trim(),
       capacity: cap,
-      genderPolicy: genderPolicy as GenderPolicy,
+      genderPolicy: genderPolicy,
     };
 
     try {


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
<!-- 아직 완전 해결이 아닌 경우 `partially fixes #번호` 사용 -->
- close #62 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 러닝 세션 생성 시 '달리기 종류(runType)'와 '참여 성별(genderPolicy)'을 미선택해도 생성되는 버그(BUG-003)를 수정했습니다.
- 폼 제출(`handleSubmit`) 단계에서 두 필드에 대한 필수 값 검증 로직을 추가하고, 미선택 시 필드별 에러 메시지를 표시하도록 처리했습니다.
- 빈 문자열(`""`) 상태로 서버에 전송되는 문제를 차단했습니다.
- `requestBody` 할당 시 강제로 사용되던 타입 캐스팅(`as RunType`, `as GenderPolicy`) 코드를 제거하여 타입 안정성을 높였습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야 할 사항이나 궁금증을 적어주세요 -->
- 강제 타입 캐스팅(`as`)을 제거하면서 발생하는 타입 에러(`"" | RunType` 할당 불가 문제)를 해결하기 위해, 검증을 통과한 직후 `if (runType === "" || genderPolicy === "") return;` 로직을 추가했습니다. 

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- 연관 버그 리포트: BUG-003 - 입력 검증 오류
