### PR TITLE
[FIX] 401 인증 만료 시 세션 캐시 누수 및 토큰 초기화 누락 오류 수정 (BUG-005)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -17,6 +17,7 @@ export default function RootLayout() {
 
   useEffect(() => {
     setUnauthorizedHandler(() => {
+      queryClient.clear();
       router.replace("/(auth)/login");
     });
   }, [router]);

--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -116,6 +116,7 @@ axiosInstance.interceptors.response.use(
     }
 
     if (shouldSkipTokenRefresh(originalRequest.url)) {
+      await clearAuthTokens();
       notifyUnauthorized(error);
       return Promise.reject(error);
     }


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
<!-- 아직 완전 해결이 아닌 경우 `partially fixes #번호` 사용 -->
- close #64 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 401 Unauthorized 에러로 로그인 화면으로 리다이렉트될 때, 이전 사용자의 데이터 캐시와 기기 토큰이 남아있는 보안 취약점(BUG-005)을 수정했습니다.
- `app/_layout.tsx`의 `setUnauthorizedHandler` 내부에 `queryClient.clear()` 호출 로직을 추가하여 TanStack Query의 전역 캐시를 완벽히 초기화하도록 처리했습니다.
- `src/api/axiosInstance.ts`의 응답 인터셉터 중 `shouldSkipTokenRefresh` 분기 및 재시도 실패 블록에 `await clearAuthTokens()`를 추가하여 기기 내 인증 토큰을 완전히 비우도록 수정했습니다.
- 이를 통해 공용 기기 환경 등에서 다른 계정으로 재로그인 시 이전 사용자의 개인정보(이름, 러닝 기록, 신청 내역 등)가 노출되는 세션 누수 현상을 차단했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야 할 사항이나 궁금증을 적어주세요 -->
- 이번 PR은 보안 및 데이터 누수(BUG-005) 해결에만 집중하기 위해 독립적인 브랜치로 분리하여 작업했습니다.
- HTTP 통신(Axios) 레이어와 비즈니스/라우팅 레이어의 결합도를 낮추기 위해 구성된 기존 `setUnauthorizedHandler` 구조를 유지하면서 안전하게 초기화 로직만 주입했습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- 연관 버그 리포트: BUG-005
