### PR TITLE
[FIX] 인증 부트스트랩 불필요한 재실행 및 리다이렉트 오류 수정 (BUG-006)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -49,7 +49,8 @@ export default function RootLayout() {
     return () => {
       isMounted = false;
     };
-  }, [router, segments]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [router]);
 
   if (!authReady) {
     return <LoadingScreen />;


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
<!-- 아직 완전 해결이 아닌 경우 `partially fixes #번호` 사용 -->
- close #66 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- 앱 실행 시 최초 1회만 수행되어야 할 인증 부트스트랩(토큰 불러오기) 로직이 화면 이동 시마다 재실행되어 발생하는 성능 저하 및 튕김 현상(BUG-006)을 수정했습니다.
- `app/_layout.tsx` 내 부트스트랩 역할을 하는 `useEffect`의 의존성 배열(deps)에서 `segments`를 제거하여, 라우트가 변경될 때마다 불필요하게 `SecureStore` 디스크 I/O가 발생하던 문제를 차단했습니다.
- 의존성 배열에서 `segments`를 제거함에 따라 발생하는 ESLint 경고를 방지하기 위해 `// eslint-disable-next-line react-hooks/exhaustive-deps` 무시 주석을 추가했습니다.
- 이를 통해 느린 기기에서도 인증 상태가 안정적으로 유지되며, 앱 생애 주기 동안 단 한 번만 인증 상태를 정확히 불러오도록 최적화했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야 할 사항이나 궁금증을 적어주세요 -->
- 본 PR은 인증 부트스트랩 최적화(BUG-006)에만 집중하기 위해 별도의 독립적인 브랜치로 분리하여 작업했습니다.
- 훅 내부에서 `segments`를 참조하고 있으나 앱 마운트 시점에 단 1회만 실행되는 것이 보장되므로, ESLint 경고 예외 처리를 통해 의도적으로 의존성 배열에서 제외했습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- 연관 버그 리포트: BUG-006
