### PR TITLE
[CHORE] 유틸리티 함수 테스트 코드 보강 및 커버리지 임계치(90%) 복구

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -22,10 +22,10 @@ module.exports = {
   // 순수 로직은 커버리지를 실제로 강제한다. 화면은 E2E 로 본다.
   coverageThreshold: {
     "src/utils/": {
-      statements: 15, // 기존 90 -> 15로 임시 변경 (TODO: 버그 해결 후 복구)
-      branches: 15, // 기존 85 -> 15로 임시 변경
-      functions: 15, // 기존 90 -> 15로 임시 변경
-      lines: 15, // 기존 90 -> 15로 임시 변경
+      statements: 90,
+      branches: 85,
+      functions: 90,
+      lines: 90,
     },
   },
 };

--- a/tests/datetime.test.ts
+++ b/tests/datetime.test.ts
@@ -1,0 +1,159 @@
+import {
+  resolveEffectiveMinimumDate,
+  parseValueToDate,
+  htmlTimeMinFromMinimum,
+  clampDateTimePartsToMinimum,
+  mergeDateAndTimeParts,
+  splitDateAndTimeFromValue,
+  displayFromValue,
+  defaultDatePartForPicker,
+  htmlDateOnlyFromLocalPart,
+  toDatetimeLocalInputValue,
+} from "../src/utils/datetime";
+
+import { formatDate, formatDisplayDate } from "@/src/utils/date";
+
+/**
+ * 이 테스트는 런타임 환경과 무관하게 순수 날짜/시간 포맷팅 유틸리티의 동작을 검증한다.
+ * 시스템 시간에 의존하여 발생하는 Flaky 테스트를 방지하기 위해 Fake Timers를 적용한다.
+ */
+describe("날짜 및 시간 유틸리티 검증 (datetime.ts)", () => {
+  const SYSTEM_TIME = new Date("2026-08-01T12:00:00").getTime();
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(SYSTEM_TIME);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  describe("resolveEffectiveMinimumDate() - 최소 선택 가능 시각 계산", () => {
+    it("★ 기준일(minimumDate)이 없을 경우, 현재 시각에 지연 시간(leadMs)을 더해 반환한다", () => {
+      const leadMs = 60 * 60 * 1000;
+      const result = resolveEffectiveMinimumDate(undefined, leadMs);
+      expect(result?.getTime()).toBe(SYSTEM_TIME + leadMs);
+    });
+
+    it("★ 기준일과 지연 시간이 모두 존재할 경우, 둘 중 더 미래의 시각을 적용한다", () => {
+      const pastDate = new Date(SYSTEM_TIME - 10000);
+      const leadMs = 60 * 1000;
+      const result = resolveEffectiveMinimumDate(pastDate, leadMs);
+      expect(result?.getTime()).toBe(SYSTEM_TIME + leadMs);
+    });
+
+    it("★★ 지연 시간(leadMs)이 음수로 주입되는 비정상적인 경우, 원본 기준일을 훼손하지 않는다", () => {
+      const validDate = new Date(SYSTEM_TIME + 10000);
+      const result = resolveEffectiveMinimumDate(validDate, -500);
+      expect(result?.getTime()).toBe(validDate.getTime());
+    });
+  });
+
+  describe("parseValueToDate() - 문자열 파싱 방어 로직", () => {
+    it("★★ 유효하지 않은 포맷이나 빈 문자열 입력 시, 앱 크래시를 방지하고 현재 시각을 반환한다", () => {
+      expect(parseValueToDate("").getTime()).toBe(SYSTEM_TIME);
+      expect(parseValueToDate("   ").getTime()).toBe(SYSTEM_TIME);
+      expect(parseValueToDate("invalid-date-string").getTime()).toBe(
+        SYSTEM_TIME,
+      );
+    });
+
+    it("★ 유효한 ISO 8601 문자열은 정확한 Date 객체로 변환되어야 한다", () => {
+      const valid = "2026-12-25T15:00:00";
+      expect(parseValueToDate(valid).getTime()).toBe(new Date(valid).getTime());
+    });
+  });
+
+  describe("htmlTimeMinFromMinimum() - HTML time input 제한 로직", () => {
+    it("★ 선택한 날짜가 최소 제한 날짜와 동일할 경우, 정확한 시간(HH:mm)을 잘라서 반환한다", () => {
+      const minLocalPart = "2026-08-15T14:30:00";
+      const draftDate = "2026-08-15";
+      expect(htmlTimeMinFromMinimum(minLocalPart, draftDate)).toBe("14:30");
+    });
+
+    it("★ 선택한 날짜가 최소 제한 날짜와 다를 경우, 시간 제한을 해제(undefined)한다", () => {
+      const minLocalPart = "2026-08-15T14:30:00";
+      const draftDate = "2026-08-20";
+      expect(htmlTimeMinFromMinimum(minLocalPart, draftDate)).toBeUndefined();
+    });
+
+    it("★★ 제한 시간 데이터가 불완전하거나 날짜가 비어있을 경우, 폼 에러 방지를 위해 제한을 강제하지 않는다", () => {
+      expect(htmlTimeMinFromMinimum("2026-08", "2026-08-15")).toBeUndefined();
+      expect(
+        htmlTimeMinFromMinimum("2026-08-15T14:30:00", "   "),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("clampDateTimePartsToMinimum() - 시간 강제 조정(Clamp)", () => {
+    it("★ 입력된 시간이 최소 제한 시간보다 과거일 경우, 제한 시간으로 끌어올려 반환한다", () => {
+      const minDate = new Date("2026-08-15T10:00:00");
+      const result = clampDateTimePartsToMinimum(
+        "2026-08-15",
+        "09:00",
+        minDate,
+      );
+      expect(result).toEqual({ date: "2026-08-15", time: "10:00" });
+    });
+
+    it("★★ 날짜 데이터가 누락되어 병합이 불가능할 경우, 의도치 않은 변형 없이 원본 데이터를 뱉는다", () => {
+      const minDate = new Date("2026-08-15T10:00:00");
+      const result = clampDateTimePartsToMinimum("", "09:00", minDate);
+      expect(result).toEqual({ date: "", time: "09:00" });
+    });
+  });
+
+  describe("포맷팅 유틸리티 (Date UI Display)", () => {
+    it("★ formatDate()는 [M.D (요일)] 포맷을 정확히 반환하며 빈 값을 뱉지 않고 안전하게 처리한다", () => {
+      expect(formatDate("")).toBe("");
+      expect(formatDate("2026-08-15T10:00:00")).toBe("8.15 (토)");
+    });
+
+    it("★★ formatDisplayDate()는 로컬과 CI의 Intl 객체 출력 포맷(오후/PM) 차이를 모두 호환한다", () => {
+      const result = formatDisplayDate("2026-08-15T14:30:00");
+      expect(result).toContain("8. 15.");
+      expect(result).toContain("토");
+      expect(result).toMatch(/(오후|PM)\s*2:30/);
+    });
+  });
+
+  describe("Form Input 연동을 위한 양방향 데이터 포맷팅", () => {
+    it("★ displayFromValue() - ISO 문자열을 화면 표시용 'YYYY-MM-DD HH:mm' 형태로 변환한다", () => {
+      expect(displayFromValue("2026-08-15T14:30:00")).toBe("2026-08-15 14:30");
+      expect(displayFromValue("")).toBe("");
+      expect(displayFromValue("invalid")).toBe("invalid");
+    });
+
+    it("★ splitDateAndTimeFromValue() - ISO 문자열을 날짜와 시간 객체로 분리한다", () => {
+      expect(splitDateAndTimeFromValue("2026-08-15T14:30:00")).toEqual({
+        date: "2026-08-15",
+        time: "14:30",
+      });
+      expect(splitDateAndTimeFromValue("invalid")).toEqual({
+        date: "",
+        time: "",
+      });
+    });
+
+    it("★ mergeDateAndTimeParts() - 분리된 날짜와 시간 문자열을 ISO 형태로 병합한다", () => {
+      expect(mergeDateAndTimeParts("2026-08-15", "14:30")).toContain(
+        "2026-08-15T14:30",
+      );
+      expect(mergeDateAndTimeParts("", "14:30")).toBe("");
+    });
+
+    it("★ defaultDatePartForPicker() - 캘린더 피커의 기본값(오늘)을 YYYY-MM-DD 형태로 제공한다", () => {
+      expect(defaultDatePartForPicker()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it("★ htmlDateOnlyFromLocalPart() - 로컬 날짜 문자열에서 날짜(YYYY-MM-DD) 부분만 안전하게 추출한다", () => {
+      expect(htmlDateOnlyFromLocalPart("2026-08-15T14:30")).toBe("2026-08-15");
+      expect(htmlDateOnlyFromLocalPart(undefined)).toBeUndefined();
+    });
+
+    it("★★ toDatetimeLocalInputValue() - 유효하지 않은 데이터 유입 시 빈 문자열로 초기화하여 폼 에러를 방지한다", () => {
+      expect(toDatetimeLocalInputValue("이상한-날짜-데이터")).toBe("");
+    });
+  });
+});

--- a/tests/reverseGeocode.test.ts
+++ b/tests/reverseGeocode.test.ts
@@ -1,0 +1,82 @@
+import * as Location from "expo-location";
+
+import { getPlaceNameFromCoordinates } from "../src/utils/reverseGeocode";
+
+// 외부 라이브러리(expo-location)를 Mock 객체로 대체하여 네트워크 및 GPS 의존성을 제거한다.
+jest.mock("expo-location");
+const mockedLocation = Location as jest.Mocked<typeof Location>;
+
+/**
+ * 좌표 기반의 주소 변환(Reverse Geocoding) 로직을 검증한다.
+ * 외부 API 에러나 비정상 응답 시 앱이 크래시되지 않는지를 중점적으로 확인한다.
+ */
+describe("역지오코딩 유틸리티 검증 (reverseGeocode.ts)", () => {
+  const FALLBACK_NAME = "선택한 위치";
+
+  beforeEach(() => {
+    // 테스트 간 격리성을 보장하기 위해 매번 Mock 호출 히스토리를 초기화한다.
+    jest.clearAllMocks();
+  });
+
+  describe("주소 데이터 정제 및 변환", () => {
+    it("★ 유효한 좌표 입력 시, 영문 행정구역명을 한국어로 번역하고 중복을 제거하여 반환한다", async () => {
+      mockedLocation.reverseGeocodeAsync.mockResolvedValueOnce([
+        {
+          name: "스타벅스",
+          street: "테헤란로",
+          streetNumber: "123",
+          region: "Seoul",
+          subregion: "Gangnam-gu",
+          city: "대한민국 서울특별시",
+          district: "역삼동",
+          formattedAddress: "대한민국 서울특별시 강남구 테헤란로 123 스타벅스",
+        } as Location.LocationGeocodedAddress,
+      ]);
+
+      const result = await getPlaceNameFromCoordinates(127.0316, 37.5013);
+
+      // 대한민국 제거, Seoul 번역, 중복된 서울특별시 제거 등 정제 파이프라인 검증
+      expect(result).toBe("서울특별시 Gangnam-gu 역삼동 테헤란로 123 스타벅스");
+      expect(mockedLocation.reverseGeocodeAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it("★ 세부 주소 파편(adminParts)이 부족할 경우, 전체 주소(formattedAddress)에서 국가명을 정제하여 반환한다", async () => {
+      mockedLocation.reverseGeocodeAsync.mockResolvedValueOnce([
+        {
+          formattedAddress: "대한민국 경기도 성남시 분당구",
+          name: null,
+          region: null,
+        } as Location.LocationGeocodedAddress,
+      ]);
+
+      const result = await getPlaceNameFromCoordinates(127.1, 37.3);
+      expect(result).toBe("경기도 성남시 분당구");
+    });
+  });
+
+  describe("네트워크 및 예외 상황 방어 로직 (Fallback)", () => {
+    it("★★ 위치 권한 거부 또는 API 500 에러 발생 시, 크래시 없이 기본(Fallback) 텍스트를 반환한다", async () => {
+      // 의도된 에러 로그가 터미널 환경을 오염시키지 않도록 임시로 Spy 처리한다.
+      const consoleSpy = jest.spyOn(console, "warn").mockImplementation(() => {
+        /* empty */
+      });
+
+      mockedLocation.reverseGeocodeAsync.mockRejectedValueOnce(
+        new Error("Location permission denied"),
+      );
+
+      const result = await getPlaceNameFromCoordinates(0, 0);
+
+      expect(result).toBe(FALLBACK_NAME);
+
+      consoleSpy.mockRestore();
+    });
+
+    it("★★ 역지오코딩 응답 배열이 비어있는 비정상 케이스에서, 안전하게 기본(Fallback) 텍스트를 반환한다", async () => {
+      mockedLocation.reverseGeocodeAsync.mockResolvedValueOnce([]);
+
+      const result = await getPlaceNameFromCoordinates(127.0, 37.0);
+      expect(result).toBe(FALLBACK_NAME);
+    });
+  });
+});


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
<!-- 아직 완전 해결이 아닌 경우 `partially fixes #번호` 사용 -->
- close #68 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- **커버리지 기술 부채 상환**: 핫픽스 배포를 위해 임시로 하향 조정했던 `src/utils/` 폴더의 테스트 커버리지 임계치를 복구했습니다.
- **`reverseGeocode` 단위 테스트 보강**: 외부 의존성(`expo-location`)을 완벽하게 모킹(Mocking)하여 네트워크 환경과 무관하게 동작하는 독립적인 테스트 환경을 구축했습니다. 
- **`datetime` 단위 테스트 보강**: 실행하는 날짜에 따라 결과가 달라지는 현상을 방지하기 위해 `jest.useFakeTimers()`를 적용하여 시간 의존성을 제거하고 엣지 케이스를 검증했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야 할 사항이나 궁금증을 적어주세요 -->
-  `reverseGeocode`에서 권한 거부 및 500 서버 에러 발생 시 앱이 튕기지 않고 Fallback 텍스트를 반환하는지 방어 로직을 검증했습니다. 이때 의도적으로 발생시킨 에러 로그(`console.warn`)가 테스트 터미널 환경을 지저분하게 만들지 않도록, `jest.spyOn`과 린트 규칙(`/* empty */`)을 준수하여 처리했습니다.
- 단순히 코드 내의 특정 글자를 찾는 방식이 아니라, 극한의 Input(빈 문자열, 비정상 포맷)이 들어왔을 때 정확한 Output이나 기본값을 내뱉는지에 집중하여 리팩토링을 고려하여 테스트를 작성했습니다.

## 📬 Reference

- `npm run test:unit -- --coverage` 실행 결과 `utils` 폴더 커버리지 90% 달성 및 전체 테스트 PASS 확인 완료.