### PR TITLE
[FIX] EAS 빌드 환경 변수 주입 오류 해결 및 위치 권한 알림 메시지 개선

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -8,8 +8,6 @@
       "developmentClient": true,
       "distribution": "internal",
       "env": {
-        "EXPO_PUBLIC_API_BASE_URL": "https://set-in-eas-secrets.com",
-        "EXPO_PUBLIC_NAVER_MAP_CLIENT_ID": "INJECTED_BY_EAS_SECRETS",
         "EXPO_PUBLIC_USE_MOCK": "true"
       }
     },
@@ -19,9 +17,7 @@
         "buildType": "apk"
       },
       "env": {
-        "EXPO_PUBLIC_API_BASE_URL": "https://set-in-eas-secrets.com",
-        "EXPO_PUBLIC_NAVER_MAP_CLIENT_ID": "INJECTED_BY_EAS_SECRETS",
-        "EXPO_PUBLIC_USE_MOCK": "true"
+        "EXPO_PUBLIC_USE_MOCK": "false"
       }
     },
     "production": {
@@ -30,8 +26,6 @@
         "buildType": "app-bundle"
       },
       "env": {
-        "EXPO_PUBLIC_API_BASE_URL": "https://set-in-eas-secrets.com",
-        "EXPO_PUBLIC_NAVER_MAP_CLIENT_ID": "INJECTED_BY_EAS_SECRETS",
         "EXPO_PUBLIC_USE_MOCK": "false"
       }
     }

--- a/src/hooks/search/useCurrentLocation.ts
+++ b/src/hooks/search/useCurrentLocation.ts
@@ -52,8 +52,8 @@ export function useCurrentLocation() {
         if (!isMounted) return;
         console.warn("위치 로드 실패", error);
         Alert.alert(
-          "현재 위치를 찾지 못해 전국 지도를 표시합니다.",
-          "원하는 위치를 찾아보세요.",
+          "위치 확인 불가",
+          "현재 위치를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.",
           [{ text: "확인" }],
         );
         setCamera(DEFAULT_LOCATION);

--- a/tests/env-guard.test.ts
+++ b/tests/env-guard.test.ts
@@ -20,17 +20,13 @@ describe("EAS production 프로파일", () => {
     expect(prod?.env?.EXPO_PUBLIC_USE_MOCK).not.toBe("true");
   });
 
-  it("★ API BASE URL 이 https 이고 로컬/터널 주소가 아니다", () => {
+  it("★ API BASE URL은 eas.json에 하드코딩되지 않아야 한다 (EAS Secrets 사용)", () => {
     const url: string | undefined = prod?.env?.EXPO_PUBLIC_API_BASE_URL;
-    expect(url).toBeDefined();
-    expect(url).toMatch(/^https:\/\//);
-    expect(url).not.toMatch(
-      /localhost|127\.0\.0\.1|ngrok|10\.0\.2\.2|192\.168\./,
-    );
+    expect(url).toBeUndefined();
   });
 
-  it("네이버 지도 클라이언트 ID 가 주입된다", () => {
-    expect(prod?.env?.EXPO_PUBLIC_NAVER_MAP_CLIENT_ID).toBeTruthy();
+  it("네이버 지도 클라이언트 ID는 eas.json에 하드코딩되지 않아야 한다 (EAS Secrets 사용)", () => {
+    expect(prod?.env?.EXPO_PUBLIC_NAVER_MAP_CLIENT_ID).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
<!-- 아직 완전 해결이 아닌 경우 `partially fixes #번호` 사용 -->
- close #71 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- `eas.json` 내 더미 환경변수(네이버 지도 Client ID 등)가 EAS Secrets 값을 덮어쓰는 문제 해결 (네이버 지도 401 인증 에러 픽스)
- `useCurrentLocation` 훅의 위치 권한 거부 및 탐색 타임아웃 시 노출되는 Alert 문구 UX 개선

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야 할 사항이나 궁금증을 적어주세요 -->
- **EAS 빌드 환경변수 우선순위 수정:** 기존에 `eas.json`에 하드코딩 되어있던 더미 값들 때문에 클라우드 빌드 시 실제 키값이 주입되지 않는 문제가 있었습니다. 이를 해결하기 위해 `eas.json`에서 해당 변수를 아예 제거하여 EAS Secrets를 정상적으로 바라보도록 수정했습니다. 설정 변경 방향이 적절한지 리뷰 부탁드립니다.
- **Alert UX 라이팅 개선:** 위치 정보를 불러오지 못했을 때 띄워주는 Alert 문구를 기계적인 느낌에서 "위치 확인 불가"로 좀 더 자연스럽고 정중하게 다듬었습니다. 우리 앱 전반적인 톤앤매너와 잘 어울리는지 확인 부탁드립니다.
- **빌드 테스트 요청:** 가능하다면 `eas build -p android --profile preview`로 빌드된 APK 에뮬레이터에서 네이버 지도가 401 에러 없이 잘 뜨는지 직접 크로스 체크해 주시면 감사하겠습니다.