### PR TITLE
[FEAT] 마이페이지 회원탈퇴 기능 구현 및 API 연동

### DIFF
--- a/app/(main)/my-page.tsx
+++ b/app/(main)/my-page.tsx
@@ -22,6 +22,7 @@ import {
 } from "../../src/components/mypage/Sections";
 
 import { logoutUser } from "@/src/api/auth/logoutUser";
+import { withdrawUser } from "@/src/api/auth/withdraswUser";
 import RightArrowSvg from "@/src/assets/icon/my-page/rightarrow.svg";
 import SettingSvg from "@/src/assets/icon/my-page/setting.svg";
 import {
@@ -99,6 +100,35 @@ export default function MyPageScreen() {
         },
       },
     ]);
+  };
+
+  const handleWithdraw = () => {
+    Alert.alert(
+      "회원탈퇴",
+      "정말 탈퇴하시겠습니까?\n모든 러닝 기록과 정보가 즉시 삭제되며 복구할 수 없습니다.",
+      [
+        { text: "취소", style: "cancel" },
+        {
+          text: "탈퇴하기",
+          style: "destructive",
+          onPress: async () => {
+            try {
+              await withdrawUser({ queryClient });
+
+              setSettingsVisible(false);
+
+              Alert.alert("알림", "회원탈퇴가 완료되었습니다.");
+              router.replace("/(auth)/login");
+            } catch {
+              Alert.alert(
+                "오류",
+                "회원탈퇴 처리 중 문제가 발생했습니다. 다시 시도해주세요.",
+              );
+            }
+          },
+        },
+      ],
+    );
   };
 
   if (isTotalLoading) {
@@ -184,12 +214,7 @@ export default function MyPageScreen() {
               />
             </Pressable>
             <View style={styles.divider} />
-            <Pressable
-              style={styles.modalItem}
-              // TODO: 회원탈퇴 로직 추가
-              // eslint-disable-next-line no-console
-              onPress={() => console.log("회원탈퇴 로직")}
-            >
+            <Pressable style={styles.modalItem} onPress={handleWithdraw}>
               <Text style={styles.modalItemText}>회원탈퇴</Text>
               <RightArrowSvg
                 width={20}

--- a/src/api/auth/authApi.index.ts
+++ b/src/api/auth/authApi.index.ts
@@ -3,12 +3,14 @@ import {
   logout as realLogout,
   refresh as realRefresh,
   signup as realSignup,
+  withdraw as realWithdraw,
 } from "@/src/api/auth/authApi";
 import {
   login as mockLogin,
   logout as mockLogout,
   refresh as mockRefresh,
   signup as mockSignup,
+  withdraw as mockWithdraw,
 } from "@/src/api/auth/authApi.mock";
 
 const isMock = process.env.EXPO_PUBLIC_USE_MOCK === "true";
@@ -40,3 +42,9 @@ export const refresh = isMock ? mockRefresh : realRefresh;
  * @returns 로그아웃 결과 메시지
  */
 export const logout = isMock ? mockLogout : realLogout;
+
+/**
+ * 회원탈퇴.
+ * @returns 탈퇴 결과 메시지
+ */
+export const withdraw = isMock ? mockWithdraw : realWithdraw;

--- a/src/api/auth/authApi.mock.ts
+++ b/src/api/auth/authApi.mock.ts
@@ -7,6 +7,7 @@ import type {
   RefreshTokenResponse,
   SignupRequest,
   SignupResponse,
+  WithdrawResponse,
 } from "@/src/types/api/auth";
 
 export const signup = async (
@@ -47,5 +48,11 @@ export const logout = async (
 ): Promise<LogoutResponse> => {
   return {
     message: "로그아웃 성공",
+  };
+};
+
+export const withdraw = async (): Promise<WithdrawResponse> => {
+  return {
+    message: "회원탈퇴 성공",
   };
 };

--- a/src/api/auth/authApi.ts
+++ b/src/api/auth/authApi.ts
@@ -8,6 +8,7 @@ import type {
   RefreshTokenResponse,
   SignupRequest,
   SignupResponse,
+  WithdrawResponse,
 } from "@/src/types/api/auth";
 
 export const signup = async (
@@ -47,5 +48,11 @@ export const logout = async (
     "/auth/logout",
     requestBody,
   );
+  return response.data;
+};
+
+export const withdraw = async (): Promise<WithdrawResponse> => {
+  const response =
+    await axiosInstance.delete<WithdrawResponse>("/auth/withdraw");
   return response.data;
 };

--- a/src/api/auth/withdraswUser.ts
+++ b/src/api/auth/withdraswUser.ts
@@ -1,0 +1,20 @@
+import type { QueryClient } from "@tanstack/react-query";
+
+import { withdraw } from "@/src/api/auth/authApi.index";
+import { clearAuthTokens } from "@/src/api/authToken";
+
+export interface WithdrawUserOptions {
+  queryClient?: QueryClient;
+}
+
+/**
+ * 서버 회원탈퇴 요청 후 성공 시 로컬 토큰, 캐시를 정리
+ */
+export async function withdrawUser(
+  options?: WithdrawUserOptions,
+): Promise<void> {
+  await withdraw();
+
+  await clearAuthTokens();
+  options?.queryClient?.clear();
+}

--- a/src/types/api/auth.ts
+++ b/src/types/api/auth.ts
@@ -62,3 +62,8 @@ export interface SignupRequest {
 export interface SignupResponse {
   userId: number;
 }
+
+/** 회원탈퇴 응답 타입 */
+export interface WithdrawResponse {
+  message?: string;
+}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
<!-- 아직 완전 해결이 아닌 경우 `partially fixes #번호` 사용 -->
- close #70 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- **회원탈퇴 API 연동:** `DELETE /auth/withdraw` 엔드포인트 연동 및 Mock/Real 환경 분리
- **클린 아키텍처 (비즈니스 로직 분리):** 탈퇴 성공 시 기기에 남은 JWT 토큰(`clearAuthTokens`)과 React Query 메모리 캐시(`queryClient.clear()`)를 완벽하게 삭제하는 `withdrawUser.ts` 분리 구현
- **안전한 사용자 경험(UX) 제공:** 
  - 실수로 탈퇴하는 것을 막기 위해 `Alert` 창을 통한 2-Depth 재확인 로직 추가

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야 할 사항이나 궁금증을 적어주세요 -->

**계정 삭제 시 잔존 캐시 초기화 (`withdrawUser.ts`)**: 단순히 API만 쏘는 것이 아니라, 탈퇴가 100% 성공했을 때만 프론트엔드의 토큰과 `queryClient` 캐시 데이터를 통째로 날리도록 로직을 격리했습니다. (다른 유저로 재로그인 시 이전 유저의 데이터가 번쩍이는 현상 차단)

**스웨거(Swagger) 엣지 케이스 대응**: 현재 회원탈퇴 스웨거 응답값이 뼈대 구조(`additionalProp`)로만 열려 있어서, 직접 Mock 런타임에서 로깅을 통해 실제 응답값이 `{"message": "회원 탈퇴 처리됨"}` 형태로 오는 것을 확인했습니다. 이에 맞춰 `WithdrawResponse` 타입을 유연하게 정의해 두었습니다.

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- 백엔드 Swagger API 명세서 (`DELETE /auth/withdraw` 참조)
- 프론트엔드 기존 로그아웃 유스케이스 (`logoutUser.ts`)