### PR TITLE
[FIX] EAS 빌드 오류 해결을 위한 .easignore 파일 추가

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -1,0 +1,59 @@
+# Learn more https://docs.github.com/en/get-started/getting-started-with-git/ignoring-files
+
+# dependencies
+
+node_modules/
+
+# Expo
+
+.expo/
+dist/
+web-build/
+expo-env.d.ts
+
+# Native
+
+.kotlin/
+_.orig._
+_.jks
+_.p8
+_.p12
+_.key
+\*.mobileprovision
+
+# Metr
+
+.metro-health-check\*
+
+# debug
+
+npm-debug._
+yarn-debug._
+yarn-error.\*
+
+# macOS
+
+.DS_Store
+\*.pem
+
+# Environment variables
+
+.env
+.env.\*
+
+# typescript
+
+\*.tsbuildinfo
+
+# generated native folders
+
+/ios
+/android
+
+# Android local config
+
+android/
+
+# IDE
+
+.idea/


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
<!-- 아직 완전 해결이 아닌 경우 `partially fixes #번호` 사용 -->
- close #77 

## 📝 Summary
- EAS 안드로이드 빌드 시 `google-services.json` 파일 누락으로 인해 빌드가 실패하는 문제를 해결했습니다.
- 깃허브 보안은 유지(`.gitignore` 적용)하면서, 클라우드 빌드 서버에는 필요한 파일이 정상적으로 전달되도록 `.easignore` 파일을 새롭게 추가했습니다.

## 🙏 Question & PR point
- **문제 원인:** 이전에 보안을 위해 `.gitignore`에 구글 서비스 파일(`google-services.json`, `GoogleService-Info.plist`)을 추가했는데, EAS 클라우드 서버에서 빌드를 돌릴 때 이 파일들까지 전송에서 제외되어 네이티브 빌드가 터지는 문제가 있었습니다.
- **해결 방식:** EAS는 프로젝트에 `.easignore` 파일이 있으면 `.gitignore` 대신 해당 파일의 규칙을 최우선으로 따릅니다. 따라서 `.easignore`를 새로 만들고, 이 파일 안에서는 구글 설정 파일들이 무시되지 않고 빌드 서버로 넘어갈 수 있도록 처리했습니다.