### PR TITLE
[FIX] 지난 러닝 세션(과거 모임) 참여 신청 제한 및 UX 개선

### DIFF
--- a/app/session-detail.tsx
+++ b/app/session-detail.tsx
@@ -57,6 +57,8 @@ export default function SessionDetailScreen() {
     );
   }
 
+  const isPastSession = new Date() > new Date(data.startAt);
+
   const participants = data.participants ?? [];
   const participantCount = participants.length;
 
@@ -216,7 +218,7 @@ export default function SessionDetailScreen() {
           </View>
         </View>
         <View style={styles.submitSection}>
-          <BottomSubmit sessionId={sessionId} />
+          <BottomSubmit sessionId={sessionId} isPastSession={isPastSession} />
         </View>
       </ScrollView>
     </View>

--- a/src/components/session-detail/BottomSubmit.tsx
+++ b/src/components/session-detail/BottomSubmit.tsx
@@ -11,9 +11,10 @@ import { AnalyticsHelper } from "@/src/utils/analytics";
 
 interface BottomSubmitProps {
   sessionId: number;
+  isPastSession?: boolean;
 }
 
-export function BottomSubmit({ sessionId }: BottomSubmitProps) {
+export function BottomSubmit({ sessionId, isPastSession }: BottomSubmitProps) {
   const [message, setMessage] = useState("");
 
   const router = useRouter();
@@ -42,13 +43,29 @@ export function BottomSubmit({ sessionId }: BottomSubmitProps) {
   });
 
   const handleApply = () => {
+    if (isPastSession) {
+      Alert.alert("신청 불가", "이미 시작 시간이 지난 러닝 모임입니다.");
+      return;
+    }
+
     joinMutation.mutate(message);
+  };
+
+  const getButtonText = () => {
+    if (isPastSession) return "마감된 모임입니다";
+    if (joinMutation.isPending) return "신청 중";
+    return "참여 신청하기";
   };
 
   return (
     <View style={styles.container}>
       <Input
-        placeholder="호스트에게 한마디 (선택)"
+        editable={!isPastSession}
+        placeholder={
+          isPastSession
+            ? "마감된 모임에는 작성할 수 없습니다."
+            : "호스트에게 한마디 (선택)"
+        }
         value={message}
         onChangeText={setMessage}
         wrapperStyle={styles.inputWrapper}
@@ -59,9 +76,9 @@ export function BottomSubmit({ sessionId }: BottomSubmitProps) {
         size="lg"
         fullWidth
         onPress={handleApply}
-        disabled={joinMutation.isPending}
+        disabled={joinMutation.isPending || isPastSession}
       >
-        {joinMutation.isPending ? "신청 중" : "참여 신청하기"}
+        {getButtonText()}
       </Button>
     </View>
   );


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
<!-- 아직 완전 해결이 아닌 경우 `partially fixes #번호` 사용 -->
- close #79 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- **방어 로직 추가:** 시작 시간이 지난(마감된) 과거 러닝 세션에 대해 불필요한 서버 요청(POST)이 발생하지 않도록, 프론트엔드 단에서 `isPastSession` 상태를 추출하여 예외 처리를 구현했습니다.
- **UX 개선 (컴포넌트 비활성화):** 유저의 혼란을 방지하기 위해 마감된 모임 진입 시 하단 텍스트 입력창(`Input`)과 참여 신청 버튼(`Button`)을 즉시 비활성화(Disabled) 상태로 변경하고, 상황에 맞는 안내 텍스트를 적용했습니다.

## 🖼 스크린샷(UI 변경시)
<img width="303" height="676" alt="image" src="https://github.com/user-attachments/assets/ac309791-65d0-42a5-a729-e8906ed9ae32" />


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야 할 사항이나 궁금증을 적어주세요 -->
- 프론트엔드 단에서 서버 리소스 낭비를 막기 위한 선제적 유효성 검사 목적으로 작업되었습니다.
- 비정상적인 클릭 이벤트에 의한 API 통신을 원천 차단하기 위해 `handleApply` 내부에서 Early Return 패턴과 `Alert.alert`를 활용했습니다. 사용자 경험(UX) 측면에서 경고창 문구("이미 시작 시간이 지난 러닝 모임입니다.")가 적절할지 리뷰 부탁드립니다.
