### PR TITLE
[FEAT] 홈 화면 주변 러닝 카드 클릭 시 상세 페이지 라우팅 연결

### DIFF
--- a/src/components/nearbyList/NearbyList.tsx
+++ b/src/components/nearbyList/NearbyList.tsx
@@ -78,7 +78,12 @@ export function NearbyList({ x, y }: NearbyListProps) {
             <NearbyItem
               key={session.id}
               session={session}
-              onPress={() => router.push("/(main)/search")}
+              onPress={() =>
+                router.push({
+                  pathname: "/session-detail",
+                  params: { id: session.id },
+                })
+              }
             />
           ))}
       </View>


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
<!-- 아직 완전 해결이 아닌 경우 `partially fixes #번호` 사용 -->
- close #81 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- **동적 라우팅 연동:** 홈 화면의 '내 주변 추천 러닝' 리스트에서 개별 카드를 클릭했을 때, 임시로 설정되어 있던 탐색 페이지(`/(main)/search`) 이동 대신 실제 모임의 상세 페이지(`/session-detail`)로 연결되도록 수정했습니다.
- **라우트 파라미터 전달:** 카드 클릭 시 해당 세션의 고유 `id` 값을 `params` (`{ id: session.id }`) 형태로 함께 전달하여, 상세 페이지 진입 시 올바른 세션 데이터를 정상적으로 페치하고 렌더링할 수 있도록 구현했습니다.

## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야 할 사항이나 궁금증을 적어주세요 -->
- 홈 화면과 상세 페이지 간의 핵심 유저 플로우(User Flow)를 연결하는 작업입니다. Expo Router의 객체 형태 네비게이션(`pathname`과 `params` 활용)을 통한 파라미터 전달 방식이 적절하게 작성되었는지 리뷰 부탁드립니다.