### PR TITLE
[FEAT] 러닝 코스 불러오기 모달 및 미리보기 카드 컴포넌트 구현

### DIFF
--- a/app/create-session.tsx
+++ b/app/create-session.tsx
@@ -1,7 +1,7 @@
 import RNSlider from "@react-native-community/slider";
 import { AxiosError } from "axios";
 import { useRouter } from "expo-router";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import {
   Alert,
   KeyboardAvoidingView,
@@ -19,13 +19,16 @@ import { Button } from "@/src/components/common/button/Button";
 import { DateTimePickerField } from "@/src/components/common/datetime-field";
 import { Select } from "@/src/components/common/select";
 import { TextField } from "@/src/components/common/textfield";
+import CoursePreviewCard from "@/src/components/create-session/CoursePreviewCard";
 import DrawCourseModal from "@/src/components/create-session/DrawCourseModal";
+import LoadCourseModal from "@/src/components/create-session/LoadCourseModal";
 import { colors, fontSizes, spacing } from "@/src/constants";
 import type {
   CreateSessionRequest,
   GenderPolicy,
   RunType,
 } from "@/src/types/api/createSession";
+import { PastCourse } from "@/src/types/domain/course";
 import { AnalyticsHelper } from "@/src/utils/analytics";
 import { paceStringToSeconds } from "@/src/utils/pace";
 import { isEmpty } from "@/src/utils/validation";
@@ -113,6 +116,38 @@ export default function CreateSessionScreen() {
 
   const [isMapModalVisible, setIsMapModalVisible] = useState(false);
   const [sessionForm, setSessionForm] = useState(initialFormState);
+
+  const [isLoadModalVisible, setIsLoadModalVisible] = useState(false);
+  const [courseAddress, setCourseAddress] = useState("");
+
+  const handleClearCourse = useCallback(() => {
+    setSessionForm((prev) => ({
+      ...prev,
+      routePolyline: [],
+      markers: [],
+      locationName: "",
+      targetDistanceKm: "",
+      locationX: "",
+      locationY: "",
+    }));
+    setCourseAddress("");
+  }, []);
+
+  const handleCourseLoaded = useCallback((course: PastCourse) => {
+    setSessionForm((prev) => ({
+      ...prev,
+      routePolyline: course.routePolyline,
+      markers: course.markers,
+      locationName: course.locationName,
+      targetDistanceKm: String(course.targetDistanceKm),
+      locationX: course.routePolyline[0]?.x.toString() || "",
+      locationY: course.routePolyline[0]?.y.toString() || "",
+      avgPace: secondsToPaceString(course.avgPaceSec),
+    }));
+    setCourseAddress(course.address);
+  }, []);
+
+  const hasCourseData = sessionForm.routePolyline.length > 1;
 
   const handleChange = <K extends keyof SessionFormState>(
     key: K,
@@ -373,23 +408,43 @@ export default function CreateSessionScreen() {
           />
 
           <Text style={styles.sectionTitle}>러닝 코스 설정</Text>
-          <Text style={styles.sectionHint}>
-            「러닝 코스 그리기」에서 좌표를 설정하면 세션 등록 시 최소
-            경로(2점)로 반영됩니다.
-          </Text>
-          <View style={styles.courseActionRow}>
-            <Button variant="outline" size="sm" flex disabled>
-              러닝 코스 불러오기
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              flex
-              onPress={() => setIsMapModalVisible(true)}
-            >
-              러닝 코스 그리기
-            </Button>
-          </View>
+          {hasCourseData ? (
+            <CoursePreviewCard
+              title={sessionForm.locationName}
+              distance={sessionForm.targetDistanceKm}
+              pace={sessionForm.avgPace}
+              address={courseAddress}
+              routePolyline={sessionForm.routePolyline}
+              onClear={handleClearCourse}
+              onLoadPress={() => setIsLoadModalVisible(true)}
+              onDrawPress={() => setIsMapModalVisible(true)}
+            />
+          ) : (
+            <>
+              <Text style={styles.sectionHint}>
+                「러닝 코스 그리기」에서 좌표를 설정하면 세션 등록 시 최소
+                경로(2점)로 반영됩니다.
+              </Text>
+              <View style={styles.courseActionRow}>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  flex
+                  onPress={() => setIsLoadModalVisible(true)}
+                >
+                  러닝 코스 불러오기
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  flex
+                  onPress={() => setIsMapModalVisible(true)}
+                >
+                  러닝 코스 그리기
+                </Button>
+              </View>
+            </>
+          )}
 
           {error.locationX ? (
             <Text style={styles.fieldError}>{error.locationX}</Text>
@@ -454,6 +509,12 @@ export default function CreateSessionScreen() {
           }));
           setIsMapModalVisible(false);
         }}
+      />
+
+      <LoadCourseModal
+        visible={isLoadModalVisible}
+        onClose={() => setIsLoadModalVisible(false)}
+        onSelect={handleCourseLoaded}
       />
     </KeyboardAvoidingView>
   );

--- a/src/api/createSession/createSessionApi.mock.ts
+++ b/src/api/createSession/createSessionApi.mock.ts
@@ -2,6 +2,7 @@ import type {
   CreateSessionRequest,
   CreateSessionResponse,
 } from "@/src/types/api/createSession";
+import { PastCourse } from "@/src/types/domain/course";
 
 export const createSession = async (
   _requestBody: CreateSessionRequest,
@@ -38,3 +39,34 @@ export const createSession = async (
     description: "열심히 하실 분들을 원합니다.",
   };
 };
+
+export const MOCK_PAST_COURSES: PastCourse[] = [
+  {
+    id: 1,
+    title: "여의도 한강공원 코스",
+    createdAt: "2023-10-25T07:00:00",
+    targetDistanceKm: 5.0,
+    avgPaceSec: 330,
+    locationName: "여의도 한강공원 멀티플라자",
+    address: "서울시 영등포구 여의도 한강공원 일대 수변 길",
+    routePolyline: [
+      { x: 126.93, y: 37.52 },
+      { x: 126.94, y: 37.53 },
+    ],
+    markers: [],
+  },
+  {
+    id: 2,
+    title: "올림픽공원 아침 러닝",
+    createdAt: "2023-10-20T06:30:00",
+    targetDistanceKm: 7.2,
+    avgPaceSec: 345,
+    locationName: "올림픽공원",
+    address: "서울시 송파구 올림픽로 424",
+    routePolyline: [
+      { x: 127.12, y: 37.51 },
+      { x: 127.13, y: 37.52 },
+    ],
+    markers: [],
+  },
+];

--- a/src/components/create-session/CoursePreviewCard.tsx
+++ b/src/components/create-session/CoursePreviewCard.tsx
@@ -1,0 +1,184 @@
+import { useMemo } from "react";
+import { View, Text, StyleSheet } from "react-native";
+
+import CloseIcon from "@/src/assets/icon/cancel.svg";
+import PinIcon from "@/src/assets/icon/create-session/pin.svg";
+import { Button } from "@/src/components/common/button/Button";
+import { NaverMapComponent } from "@/src/components/common/map/NaverMapComponent";
+import { colors, spacing, fontSizes, borderRadius } from "@/src/constants";
+import type { RoutePolyline } from "@/src/types/domain/createSessionDraft";
+
+interface CoursePreviewCardProps {
+  title: string;
+  distance: string;
+  pace?: string;
+  address?: string;
+  routePolyline: RoutePolyline;
+  onClear: () => void;
+  onLoadPress: () => void;
+  onDrawPress: () => void;
+}
+
+export default function CoursePreviewCard({
+  title,
+  distance,
+  pace,
+  address,
+  routePolyline,
+  onClear,
+  onLoadPress,
+  onDrawPress,
+}: CoursePreviewCardProps) {
+  const routePath = useMemo(
+    () => routePolyline.map((p) => ({ latitude: p.y, longitude: p.x })),
+    [routePolyline],
+  );
+
+  const mapCamera = useMemo(() => {
+    if (routePath.length > 0) {
+      return {
+        latitude: routePath[0].latitude,
+        longitude: routePath[0].longitude,
+        zoom: 11,
+      };
+    }
+    return undefined;
+  }, [routePath]);
+
+  return (
+    <View style={styles.cardContainer}>
+      <View style={styles.header}>
+        <Text style={styles.title} numberOfLines={1}>
+          {title || "사용자 지정 코스"}
+        </Text>
+        <Button
+          variant="text"
+          iconOnly
+          onPress={onClear}
+          startIcon={
+            <CloseIcon width={18} height={18} color={colors.gray500} />
+          }
+          wrapperStyle={styles.closeButton}
+          hitSlop={8}
+        />
+      </View>
+
+      <View style={styles.infoRow}>
+        <View style={styles.infoBlock}>
+          <Text style={styles.infoLabel}>총 거리</Text>
+          <Text style={styles.infoValue}>{distance}km</Text>
+        </View>
+        <View style={styles.divider} />
+        <View style={styles.infoBlock}>
+          <Text style={styles.infoLabel}>평균 페이스</Text>
+          <Text style={styles.infoValueText}>
+            {pace ? `${pace}/km` : "- /km"}
+          </Text>
+        </View>
+      </View>
+
+      {address && (
+        <View style={styles.addressRow}>
+          <PinIcon width={16} height={16} color={colors.main} />
+          <View style={styles.addressTextContainer}>
+            <Text style={styles.addressTitle}>
+              {address.split(" ")[0]} {address.split(" ")[1]}
+            </Text>
+            <Text style={styles.addressDesc} numberOfLines={1}>
+              {address}
+            </Text>
+          </View>
+        </View>
+      )}
+
+      <View style={styles.mapContainer} pointerEvents="none">
+        <NaverMapComponent
+          camera={mapCamera}
+          routePath={routePath}
+          isScrollGesturesEnabled={false}
+          isZoomGesturesEnabled={false}
+          style={StyleSheet.absoluteFillObject}
+        />
+      </View>
+
+      <View style={styles.actionRow}>
+        <Button variant="outline" size="sm" flex onPress={onLoadPress}>
+          러닝 코스 불러오기
+        </Button>
+        <Button variant="outline" size="sm" flex onPress={onDrawPress}>
+          지도 러닝 코스 그리기
+        </Button>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  cardContainer: {
+    backgroundColor: colors.white,
+    borderRadius: borderRadius.lg,
+    padding: spacing.base,
+    borderWidth: 1,
+    borderColor: colors.border,
+    width: "100%",
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  title: {
+    fontSize: fontSizes.base,
+    fontWeight: "700",
+    color: colors.text,
+    flex: 1,
+  },
+  closeButton: {
+    padding: spacing.xxs,
+    backgroundColor: colors.bgSecondary,
+    borderRadius: 12,
+  },
+  infoRow: { flexDirection: "row", marginTop: spacing.md, gap: spacing.base },
+  infoBlock: { flex: 1 },
+  infoLabel: {
+    fontSize: fontSizes.xs,
+    color: colors.textSecondary,
+    marginBottom: 2,
+  },
+  infoValue: { fontSize: fontSizes.sm, fontWeight: "600", color: colors.main },
+  infoValueText: {
+    fontSize: fontSizes.sm,
+    fontWeight: "600",
+    color: colors.text,
+  },
+  divider: {
+    width: 1,
+    backgroundColor: colors.border,
+    marginVertical: spacing.xs,
+  },
+  addressRow: {
+    flexDirection: "row",
+    marginTop: spacing.base,
+    gap: spacing.xs,
+    alignItems: "flex-start",
+  },
+  addressTextContainer: { flex: 1 },
+  addressTitle: {
+    fontSize: fontSizes.sm,
+    fontWeight: "700",
+    color: colors.text,
+  },
+  addressDesc: {
+    fontSize: fontSizes.xs,
+    color: colors.textSecondary,
+    marginTop: 2,
+  },
+  mapContainer: {
+    height: 140,
+    borderRadius: borderRadius.md,
+    overflow: "hidden",
+    marginTop: spacing.base,
+    backgroundColor: colors.bgSecondary,
+  },
+  actionRow: { flexDirection: "row", gap: spacing.sm, marginTop: spacing.base },
+});

--- a/src/components/create-session/LoadCourseModal.tsx
+++ b/src/components/create-session/LoadCourseModal.tsx
@@ -1,0 +1,205 @@
+import { Ionicons } from "@expo/vector-icons";
+import React, { useState, useCallback } from "react";
+import {
+  Modal,
+  View,
+  Text,
+  StyleSheet,
+  FlatList,
+  Pressable,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { MOCK_PAST_COURSES } from "@/src/api/createSession/createSessionApi.mock";
+import BackIcon from "@/src/assets/icon/back.svg";
+import { Button } from "@/src/components/common/button/Button";
+import { colors, spacing, fontSizes, borderRadius } from "@/src/constants";
+import { PastCourse } from "@/src/types/domain/course";
+import { secondsToPaceString } from "@/src/utils";
+import { formatDate } from "@/src/utils/date";
+
+interface LoadCourseModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onSelect: (course: PastCourse) => void;
+}
+
+interface CourseItemProps {
+  item: PastCourse;
+  isSelected: boolean;
+  onPress: (id: number) => void;
+}
+
+const CourseItem = React.memo(
+  ({ item, isSelected, onPress }: CourseItemProps) => (
+    <Pressable
+      style={[styles.itemContainer, isSelected && styles.itemSelected]}
+      onPress={() => onPress(item.id)}
+    >
+      <View style={styles.itemImagePlaceholder}>
+        {/* TODO: 추후 백엔드 제공 썸네일 이미지로 교체 (이미지 로드 실패 시 현재 아이콘 사용) */}
+        <Ionicons name="map-outline" size={24} color={colors.gray400} />
+      </View>
+      <View style={styles.itemContent}>
+        <Text style={styles.itemTitle}>{item.title}</Text>
+        <Text style={styles.itemDate}>{formatDate(item.createdAt)}</Text>
+        <Text style={styles.itemMeta}>
+          {item.targetDistanceKm}km | {secondsToPaceString(item.avgPaceSec)}/km
+        </Text>
+      </View>
+      <View style={styles.radioContainer}>
+        <View
+          style={[styles.radioOuter, isSelected && styles.radioOuterSelected]}
+        >
+          {isSelected && <View style={styles.radioInner} />}
+        </View>
+      </View>
+    </Pressable>
+  ),
+);
+
+CourseItem.displayName = "CourseItem";
+
+export default function LoadCourseModal({
+  visible,
+  onClose,
+  onSelect,
+}: LoadCourseModalProps) {
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  const handleConfirm = () => {
+    const course = MOCK_PAST_COURSES.find((c) => c.id === selectedId);
+    if (course) {
+      onSelect(course);
+      onClose();
+    }
+  };
+
+  const handleItemPress = useCallback((id: number) => {
+    setSelectedId(id);
+  }, []);
+
+  const renderItem = useCallback(
+    ({ item }: { item: PastCourse }) => (
+      <CourseItem
+        item={item}
+        isSelected={selectedId === item.id}
+        onPress={handleItemPress}
+      />
+    ),
+    [selectedId, handleItemPress],
+  );
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <SafeAreaView style={styles.root}>
+        <View style={styles.header}>
+          <View style={styles.headerLeft}>
+            <Button
+              onPress={onClose}
+              variant="text"
+              iconOnly
+              startIcon={<BackIcon width={17} height={17} />}
+            />
+          </View>
+          <Text style={styles.headerTitle}>러닝 코스 불러오기</Text>
+        </View>
+
+        <FlatList
+          data={MOCK_PAST_COURSES}
+          keyExtractor={(item) => String(item.id)}
+          renderItem={renderItem}
+          extraData={selectedId}
+          contentContainerStyle={styles.listContent}
+          showsVerticalScrollIndicator={false}
+        />
+
+        <View style={styles.bottomFixed}>
+          <Button
+            variant="primary"
+            fullWidth
+            disabled={!selectedId}
+            onPress={handleConfirm}
+          >
+            선택 코스 불러오기
+          </Button>
+        </View>
+      </SafeAreaView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: colors.bg },
+  header: {
+    height: 56,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: spacing.base,
+    borderBottomWidth: 1,
+    borderColor: colors.border,
+  },
+  headerLeft: {
+    position: "absolute",
+    left: spacing.base,
+    zIndex: 1,
+  },
+  headerTitle: {
+    fontSize: fontSizes.md,
+    fontWeight: "600",
+    color: colors.text,
+  },
+  listContent: { padding: spacing.base, gap: spacing.sm },
+  itemContainer: {
+    flexDirection: "row",
+    padding: spacing.base,
+    backgroundColor: colors.white,
+    borderRadius: borderRadius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    alignItems: "center",
+  },
+  itemSelected: { borderColor: colors.main },
+  itemImagePlaceholder: {
+    width: 60,
+    height: 60,
+    backgroundColor: colors.bgSecondary,
+    borderRadius: borderRadius.md,
+    alignItems: "center",
+    justifyContent: "center",
+    marginRight: spacing.md,
+  },
+  itemContent: { flex: 1, gap: 2 },
+  itemTitle: { fontSize: fontSizes.sm, fontWeight: "700", color: colors.text },
+  itemDate: { fontSize: fontSizes.xs, color: colors.textSecondary },
+  itemMeta: { fontSize: fontSizes.xs, color: colors.gray600, marginTop: 2 },
+  radioContainer: { paddingLeft: spacing.sm },
+  radioOuter: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    borderWidth: 2,
+    borderColor: colors.gray300,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  radioOuterSelected: { borderColor: colors.main },
+  radioInner: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+    backgroundColor: colors.main,
+  },
+  bottomFixed: {
+    padding: spacing.base,
+    paddingBottom: spacing.xl,
+    backgroundColor: colors.white,
+    borderTopWidth: 1,
+    borderColor: colors.border,
+  },
+});

--- a/src/types/domain/course.ts
+++ b/src/types/domain/course.ts
@@ -1,0 +1,16 @@
+import type { RoutePoint } from "../api/session-detail";
+
+import type { Session } from "@/src/types/api/createSession";
+
+type CourseCoreProps = Pick<
+  Session,
+  "title" | "locationName" | "targetDistanceKm" | "avgPaceSec" | "markers"
+>;
+
+export interface PastCourse extends CourseCoreProps {
+  id: number;
+  createdAt: string;
+  address: string;
+  thumbnailUrl?: string;
+  routePolyline: RoutePoint[];
+}


### PR DESCRIPTION
## 📣 Related Issue
<!-- 관련 이슈를 적어주세요. -->
<!-- 아직 완전 해결이 아닌 경우 `partially fixes #번호` 사용 -->
- close #84 

## 📝 Summary
<!-- 해당 PR의 주요 작업 내용을 적어주세요 -->
- **러닝 코스 불러오기 모달(`LoadCourseModal`) 및 미리보기 카드(`CoursePreviewCard`) UI 구현**
- **도메인 타입 및 Mock 데이터 구축**: 백엔드 API 명세 확정 전 프론트엔드 UI 병렬 작업을 위해, 기존 `Session` 타입에서 `Pick` 유틸리티를 활용해 `PastCourse` 타입을 정의하고 Mock 데이터를 구성했습니다.
- **메인 화면(`CreateSessionScreen`) 연동**: 불러온 코스 데이터 유무에 따른 조건부 렌더링을 적용하고, 폼 상태 업데이트 시 데이터 포맷팅 로직을 연동했습니다.
- **성능 최적화 및 레이아웃 개선**: `FlatList` 렌더링 최적화 로직 적용 및 모달 헤더 중앙 정렬 레이아웃을 고도화했습니다.

## 🖼 스크린샷(UI 변경시)
<!-- 변경된 UI의 스크린샷이나 GIF를 첨부해주세요 -->
<img width="394" height="874" alt="image" src="https://github.com/user-attachments/assets/6ad725e4-1e09-4b00-a54d-d322ea43093e" />
<img width="392" height="874" alt="image" src="https://github.com/user-attachments/assets/29d67714-f722-4a52-990c-e0bf62877e6c" />


## 🙏 Question & PR point
<!-- PR과정에서 다른 팀원이 알아야 할 사항이나 궁금증을 적어주세요 -->
1. **타입 설계 및 데이터 포맷팅**
   - 완전히 새로운 인터페이스를 파지 않고, 기존 `Session` 타입에서 코스 관련 필드만 `Pick`으로 추출하여 `PastCourse`를 정의했습니다. 백엔드(숫자 타입)와 폼 UI(문자열 타입) 간의 간극을 줄이기 위해 `handleCourseLoaded`에서 포맷팅(`secondsToPaceString` 등)을 거쳐 폼 상태에 넣도록 했는데, 이 데이터 흐름이 자연스러운지 확인 부탁드립니다.

2. **FlatList 렌더링 최적화**
   - 리스트 성능 최적화를 위해 `CourseItem`을 `React.memo`(displayName 명시)로 감쌌습니다.
   - 오래된 클로저를 방지하기 위해 자식 컴포넌트에서 클릭 시 본인의 `id`를 직접 넘겨주도록 수정하여 `handleItemPress`의 의존성 배열을 `[]`로 비웠고, `FlatList`의 `extraData={selectedId}`를 활용해 선택 상태가 바뀐 아이템만 리렌더링되도록 처리했습니다. 최적화 로직에 누락된 부분이 없는지 리뷰 부탁드립니다.

3. **헤더 레이아웃 & 아이콘 Placeholder 전략**
   - 모달 헤더의 텍스트가 미세하게 쏠리지 않고 완벽한 중앙 정렬을 이루도록, 좌측 닫기/뒤로가기 버튼에 `position: absolute`를 적용했습니다.
   - 디자인 시스템 일관성을 위해 닫기/뒤로가기 버튼은 공통 `<Button>` 컴포넌트와 커스텀 SVG를 활용했습니다. 다만, **과거 코스 썸네일 이미지** 부분은 추후 서버 연동 시 교체하기 위해 임시로 `Ionicons`를 배치하고, `TODO` 주석(이미지 로드 실패 시 Fallback UI로 활용 예정)을 남겨두었습니다. 이 방향성에 대한 의견 부탁드립니다!

## 📬 Reference
<!-- 참고한 코드의 출처를 작성해주세요 -->
- 피그마 RunSpot 디자인 (러닝 모임 만들기 - 코스 불러오기)